### PR TITLE
新增 001-get-user-story 功能規格與實作計畫

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,10 @@
 # 開發指引
 
 **請遵循 AGENTS.md** 的規範
+
+## Active Technologies
+- C# / .NET 9 + StackExchange.Redis、System.Text.Json、Microsoft.Extensions.DependencyInjection (001-get-user-story)
+- Redis（StackExchange.Redis） (001-get-user-story)
+
+## Recent Changes
+- 001-get-user-story: Added C# / .NET 9 + StackExchange.Redis、System.Text.Json、Microsoft.Extensions.DependencyInjection

--- a/specs/001-get-user-story/checklists/requirements.md
+++ b/specs/001-get-user-story/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: 取得 User Story 層級資訊
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 所有檢查項目均通過驗證
+- 規格書中沒有 [NEEDS CLARIFICATION] 標記，所有不明確的部分已透過合理假設處理並記錄於 Assumptions 區塊
+- Work Item Type 階層定義（User Story/Feature/Epic 為「以上」）已記錄於 Assumptions，使用者可在 clarify 階段調整

--- a/specs/001-get-user-story/contracts/redis-user-story-resolution.json
+++ b/specs/001-get-user-story/contracts/redis-user-story-resolution.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UserStoryResolutionResult",
+  "description": "User Story 解析結果的 Redis 資料契約，儲存於 AzureDevOps:WorkItems:UserStories",
+  "type": "object",
+  "required": ["items", "totalCount", "alreadyUserStoryCount", "foundViaRecursionCount", "notFoundCount", "originalFetchFailedCount"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "description": "所有 Work Item 的解析結果",
+      "items": {
+        "$ref": "#/$defs/UserStoryResolutionOutput"
+      }
+    },
+    "totalCount": {
+      "type": "integer",
+      "description": "總 Work Item 數量"
+    },
+    "alreadyUserStoryCount": {
+      "type": "integer",
+      "description": "原始即為 User Story 以上的數量"
+    },
+    "foundViaRecursionCount": {
+      "type": "integer",
+      "description": "透過遞迴找到的數量"
+    },
+    "notFoundCount": {
+      "type": "integer",
+      "description": "無法找到的數量"
+    },
+    "originalFetchFailedCount": {
+      "type": "integer",
+      "description": "原始取得失敗的數量"
+    }
+  },
+  "$defs": {
+    "UserStoryResolutionOutput": {
+      "type": "object",
+      "required": ["workItemId", "isSuccess", "resolutionStatus"],
+      "properties": {
+        "workItemId": {
+          "type": "integer",
+          "description": "原始 Work Item ID"
+        },
+        "title": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 標題"
+        },
+        "type": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 類型（User Story、Task、Bug 等）"
+        },
+        "state": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 狀態"
+        },
+        "url": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 網址"
+        },
+        "originalTeamName": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 團隊名稱"
+        },
+        "isSuccess": {
+          "type": "boolean",
+          "description": "原始 Work Item 是否取得成功"
+        },
+        "errorMessage": {
+          "type": ["string", "null"],
+          "description": "原始 Work Item 取得失敗時的錯誤訊息"
+        },
+        "resolutionStatus": {
+          "type": "string",
+          "enum": ["alreadyUserStoryOrAbove", "foundViaRecursion", "notFound", "originalFetchFailed"],
+          "description": "User Story 解析結果狀態"
+        },
+        "userStory": {
+          "oneOf": [
+            { "$ref": "#/$defs/UserStoryInfo" },
+            { "type": "null" }
+          ],
+          "description": "找到的 User Story 資訊（僅 alreadyUserStoryOrAbove 與 foundViaRecursion 時有值）"
+        }
+      }
+    },
+    "UserStoryInfo": {
+      "type": "object",
+      "required": ["workItemId", "title", "type", "state", "url"],
+      "properties": {
+        "workItemId": {
+          "type": "integer",
+          "description": "User Story 的 Work Item ID"
+        },
+        "title": {
+          "type": "string",
+          "description": "User Story 標題"
+        },
+        "type": {
+          "type": "string",
+          "description": "Work Item 類型（User Story / Feature / Epic）"
+        },
+        "state": {
+          "type": "string",
+          "description": "Work Item 狀態"
+        },
+        "url": {
+          "type": "string",
+          "description": "Work Item 網址"
+        }
+      }
+    }
+  }
+}

--- a/specs/001-get-user-story/data-model.md
+++ b/specs/001-get-user-story/data-model.md
@@ -1,0 +1,149 @@
+# Data Model: 取得 User Story 層級資訊
+
+**Feature Branch**: `001-get-user-story`
+**Date**: 2026-02-17
+
+## 實體變更
+
+### 既有實體擴充
+
+#### WorkItem（Domain Entity）
+
+新增欄位：
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| ParentWorkItemId | int? | 否 | 父層級 Work Item 的 ID，從 Azure DevOps API 的 relations 中解析 |
+
+> 注意：此欄位為 nullable，因為頂層 Work Item（如 Epic）沒有 Parent。
+
+---
+
+### 新增實體
+
+#### UserStoryResolutionStatus（Enum）
+
+表示 Work Item 的 User Story 解析結果狀態。
+
+| 值 | 名稱 | 說明 |
+|----|------|------|
+| 0 | AlreadyUserStoryOrAbove | 原始 Type 即為 User Story 以上的類型 |
+| 1 | FoundViaRecursion | 透過遞迴找到 User Story 以上的類型 |
+| 2 | NotFound | 無法找到 User Story 以上的類型 |
+| 3 | OriginalFetchFailed | 原始的 Work Item 就無法取得資訊 |
+
+---
+
+#### UserStoryResolutionOutput（Application DTO）
+
+代表單一 Work Item 經過 User Story 解析後的結果。
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| WorkItemId | int | 是 | 原始 Work Item ID |
+| Title | string? | 否 | 原始 Work Item 標題（取得失敗時為 null） |
+| Type | string? | 否 | 原始 Work Item 類型（取得失敗時為 null） |
+| State | string? | 否 | 原始 Work Item 狀態（取得失敗時為 null） |
+| Url | string? | 否 | 原始 Work Item 網址（取得失敗時為 null） |
+| OriginalTeamName | string? | 否 | 原始 Work Item 團隊名稱（取得失敗時為 null） |
+| IsSuccess | bool | 是 | 原始 Work Item 是否取得成功 |
+| ErrorMessage | string? | 否 | 原始 Work Item 取得失敗時的錯誤訊息 |
+| ResolutionStatus | UserStoryResolutionStatus | 是 | 解析結果狀態 |
+| UserStory | UserStoryInfo? | 否 | 找到的 User Story 資訊（僅 AlreadyUserStoryOrAbove 與 FoundViaRecursion 時有值） |
+
+---
+
+#### UserStoryInfo（Application DTO）
+
+代表透過解析找到的 User Story（或更高層級）資訊。
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| WorkItemId | int | 是 | User Story 的 Work Item ID |
+| Title | string | 是 | User Story 標題 |
+| Type | string | 是 | Work Item 類型（User Story / Feature / Epic） |
+| State | string | 是 | Work Item 狀態 |
+| Url | string | 是 | Work Item 網址 |
+
+---
+
+#### UserStoryResolutionResult（Application DTO）
+
+彙總所有 Work Item 的 User Story 解析結果。
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| Items | List\<UserStoryResolutionOutput\> | 是 | 所有解析結果 |
+| TotalCount | int | 是 | 總 Work Item 數量 |
+| AlreadyUserStoryCount | int | 是 | 原始即為 User Story 以上的數量 |
+| FoundViaRecursionCount | int | 是 | 透過遞迴找到的數量 |
+| NotFoundCount | int | 是 | 無法找到的數量 |
+| OriginalFetchFailedCount | int | 是 | 原始取得失敗的數量 |
+
+---
+
+### 基礎設施層模型擴充
+
+#### AzureDevOpsWorkItemResponse（新增 Relations 欄位）
+
+新增欄位以接收 API 回傳的關聯資料：
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| Relations | List\<AzureDevOpsRelationResponse\>? | 否 | Work Item 的關聯清單 |
+
+---
+
+#### AzureDevOpsRelationResponse（新增模型）
+
+代表 Azure DevOps API 回傳的單一關聯。
+
+| 欄位 | 型別 | 必填 | 說明 |
+|------|------|------|------|
+| Rel | string | 是 | 關聯類型（如 `System.LinkTypes.Hierarchy-Reverse` 表示 Parent） |
+| Url | string | 是 | 關聯目標的 API URL |
+| Attributes | Dictionary\<string, object?\>? | 否 | 關聯的屬性 |
+
+> Parent 關聯識別：`Rel == "System.LinkTypes.Hierarchy-Reverse"`
+> Parent ID 解析：從 `Url` 末尾的數字提取（如 `.../workitems/12345` → `12345`）
+
+---
+
+## 狀態轉換
+
+```
+WorkItem 載入
+    │
+    ├─ IsSuccess == false ──────────→ OriginalFetchFailed
+    │
+    ├─ Type ∈ {User Story, Feature, Epic}
+    │       ──────────→ AlreadyUserStoryOrAbove（UserStory = 自身資訊）
+    │
+    └─ Type ∉ {User Story, Feature, Epic}
+            │
+            ├─ 遞迴找到 Parent 且 Type ∈ 目標集合
+            │       ──────────→ FoundViaRecursion（UserStory = Parent 資訊）
+            │
+            └─ 遞迴失敗（無 Parent / API 失敗 / 循環 / 超過深度）
+                    ──────────→ NotFound
+```
+
+## 常數定義
+
+### Redis Keys
+
+| 常數名稱 | 值 | 說明 |
+|----------|-----|------|
+| AzureDevOpsUserStories | `AzureDevOps:WorkItems:UserStories` | User Story 解析結果的 Redis Key |
+
+### Work Item Type 常數
+
+| 常數名稱 | 值 | 說明 |
+|----------|-----|------|
+| UserStoryOrAboveTypes | `{"User Story", "Feature", "Epic"}` | 視為 User Story 以上的類型集合 |
+
+### 遞迴限制
+
+| 常數名稱 | 值 | 說明 |
+|----------|-----|------|
+| MaxRecursionDepth | 10 | 遞迴查找 Parent 的最大深度 |

--- a/specs/001-get-user-story/plan.md
+++ b/specs/001-get-user-story/plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan: 取得 User Story 層級資訊
+
+**Branch**: `001-get-user-story` | **Date**: 2026-02-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-get-user-story/spec.md`
+
+## Summary
+
+新增 `get-user-story` console arg，從 Redis 讀取既有的 Work Item 資料，對每個 Work Item 判斷是否為 User Story 以上層級。若不是，透過 Azure DevOps API 遞迴查找 Parent 直到找到 User Story 或更高層級。處理結果（含四種解析狀態）寫入新的 Redis Key `AzureDevOps:WorkItems:UserStories`。
+
+技術方式：利用現有 `$expand=all` API 回傳的 `relations` 陣列解析 Parent 關係，無需額外 API endpoint。擴充既有的回應模型與 Mapper，新增 `GetUserStoryTask` 遵循現有 Task Pattern。
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9
+**Primary Dependencies**: StackExchange.Redis、System.Text.Json、Microsoft.Extensions.DependencyInjection
+**Storage**: Redis（StackExchange.Redis）
+**Testing**: xUnit 2.9.2 + Moq 4.20.72
+**Target Platform**: Linux / Windows Console Application
+**Project Type**: Clean Architecture 多層專案（Domain、Application、Infrastructure、Console）
+**Performance Goals**: 無特殊效能需求（批次處理，非即時請求）
+**Constraints**: 遞迴深度上限 10 層、避免循環參照
+**Scale/Scope**: 處理數十至數百個 Work Item
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原則 | 狀態 | 說明 |
+|------|------|------|
+| I. TDD | ✅ 通過 | 所有新增類別將遵循 Red-Green-Refactor 循環 |
+| II. DDD/CQRS | ✅ 通過 | 領域實體擴充於 Domain Layer、Task 實作於 Application Layer |
+| III. SOLID | ✅ 通過 | 新增類別各有單一職責，透過介面注入依賴 |
+| IV. KISS | ✅ 通過 | 不建立不必要的抽象，Task 直接實作 ITask |
+| V. 錯誤處理 | ✅ 通過 | 使用 Result Pattern，不使用 try-catch |
+| VI. 效能與快取 | ✅ 通過 | 優先從 Redis 讀取既有資料，避免重複 API 呼叫 |
+| VII. 避免硬編碼 | ✅ 通過 | 類型集合、Redis Key、深度限制使用常數管理 |
+| VIII. 文件與註解 | ✅ 通過 | 所有公開成員加入繁體中文 XML Summary |
+| IX. JSON 序列化 | ✅ 通過 | 使用 JsonExtensions（ToJson / ToTypedObject） |
+| X. Program.cs | ✅ 通過 | 不修改 Program.cs，僅擴充 ServiceCollectionExtensions |
+| XI. 單一類別檔案 | ✅ 通過 | 每個新類別獨立為一個檔案 |
+| XII. RESTful API | ⬜ 不適用 | 本功能不涉及 API endpoint |
+| XIII. 組態管理 | ✅ 通過 | 無新增組態，使用既有 AzureDevOps 設定 |
+| XIV. 程式碼重用 | ✅ 通過 | 重用 IRedisService、IAzureDevOpsRepository、JsonExtensions 等既有元件 |
+
+### Post-Design Re-check
+
+| 原則 | 狀態 | 說明 |
+|------|------|------|
+| II. DDD/CQRS | ✅ 通過 | WorkItem 擴充 ParentWorkItemId 欄位仍為 Domain Entity 職責 |
+| III. SOLID | ✅ 通過 | UserStoryResolutionStatus enum 獨立檔案、新 DTO 各自獨立 |
+| VII. 避免硬編碼 | ✅ 通過 | WorkItemTypeConstants 集中管理類型清單 |
+| XIV. 程式碼重用 | ✅ 通過 | 見 research.md R-006 可重用元件清單 |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-get-user-story/
+├── plan.md                                    # 本檔案
+├── spec.md                                    # 需求規格
+├── research.md                                # 研究結果
+├── data-model.md                              # 資料模型設計
+├── quickstart.md                              # 快速開始指南
+├── contracts/
+│   └── redis-user-story-resolution.json       # Redis 資料契約（JSON Schema）
+├── checklists/
+│   └── requirements.md                        # 需求品質檢查表
+└── tasks.md                                   # 任務清單（由 /speckit.tasks 產生）
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── ReleaseKit.Domain/
+│   ├── Entities/
+│   │   └── WorkItem.cs                        # [修改] 新增 ParentWorkItemId 欄位
+│   └── Common/
+│       └── (無變更)
+│
+├── ReleaseKit.Common/
+│   └── Constants/
+│       ├── RedisKeys.cs                       # [修改] 新增 AzureDevOpsUserStories 常數
+│       └── WorkItemTypeConstants.cs           # [新增] User Story 以上類型常數集合
+│
+├── ReleaseKit.Application/
+│   ├── Tasks/
+│   │   ├── TaskType.cs                        # [修改] 新增 GetUserStory enum 值
+│   │   ├── TaskFactory.cs                     # [修改] 新增 GetUserStory case
+│   │   └── GetUserStoryTask.cs                # [新增] 核心任務邏輯
+│   └── Common/
+│       ├── UserStoryResolutionStatus.cs       # [新增] 解析結果狀態 Enum
+│       ├── UserStoryResolutionOutput.cs       # [新增] 單一結果 DTO
+│       ├── UserStoryResolutionResult.cs       # [新增] 彙總結果 DTO
+│       └── UserStoryInfo.cs                   # [新增] User Story 資訊 DTO
+│
+├── ReleaseKit.Infrastructure/
+│   └── AzureDevOps/
+│       ├── Models/
+│       │   ├── AzureDevOpsWorkItemResponse.cs # [修改] 新增 Relations 欄位
+│       │   └── AzureDevOpsRelationResponse.cs # [新增] 關聯回應模型
+│       └── Mappers/
+│           └── AzureDevOpsWorkItemMapper.cs   # [修改] 解析 Parent ID
+│
+└── ReleaseKit.Console/
+    ├── Parsers/
+    │   └── CommandLineParser.cs               # [修改] 新增 get-user-story 指令對應
+    └── Extensions/
+        └── ServiceCollectionExtensions.cs     # [修改] 註冊 GetUserStoryTask
+
+tests/
+├── ReleaseKit.Application.Tests/
+│   └── Tasks/
+│       └── GetUserStoryTaskTests.cs           # [新增] 核心任務測試
+├── ReleaseKit.Infrastructure.Tests/
+│   └── AzureDevOps/
+│       └── Mappers/
+│           └── AzureDevOpsWorkItemMapperTests.cs  # [修改] 新增 Parent ID 解析測試
+├── ReleaseKit.Console.Tests/
+│   └── Parsers/
+│       └── CommandLineParserTests.cs          # [修改] 新增 get-user-story 測試
+└── ReleaseKit.Common.Tests/
+    └── Constants/
+        └── WorkItemTypeConstantsTests.cs      # [新增] 類型常數測試
+```
+
+**Structure Decision**: 遵循既有 Clean Architecture 四層結構。所有新增檔案放置於各層對應的目錄中，修改檔案僅做最小幅度擴充。無需新增專案或目錄層級。
+
+## Complexity Tracking
+
+> 無違規項目，所有設計遵循 Constitution 原則。

--- a/specs/001-get-user-story/quickstart.md
+++ b/specs/001-get-user-story/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: 取得 User Story 層級資訊
+
+**Feature Branch**: `001-get-user-story`
+**Date**: 2026-02-17
+
+## 前置條件
+
+1. Redis 中已有 Work Item 資料（透過 `fetch-azure-workitems` 指令產生）
+2. Azure DevOps 設定已完成（`appsettings.json` 中的 `AzureDevOps` 區塊）
+
+## 執行流程
+
+### 步驟一：確保 Work Item 資料已載入
+
+```bash
+dotnet run --project src/ReleaseKit.Console -- fetch-azure-workitems
+```
+
+此步驟會將 Work Item 資料寫入 Redis Key `AzureDevOps:WorkItems`。
+
+### 步驟二：執行 User Story 解析
+
+```bash
+dotnet run --project src/ReleaseKit.Console -- get-user-story
+```
+
+此指令會：
+1. 從 Redis 讀取 `AzureDevOps:WorkItems` 中的 Work Item 資料
+2. 對每個 Work Item 判斷是否已為 User Story 以上層級
+3. 若不是，透過 Azure DevOps API 遞迴查找 Parent 直到找到 User Story 或更高層級
+4. 將所有結果（含統計資訊）寫入 Redis Key `AzureDevOps:WorkItems:UserStories`
+5. 輸出 JSON 結果至 stdout
+
+## 輸出範例
+
+```json
+{
+  "items": [
+    {
+      "workItemId": 12345,
+      "title": "實作使用者登入功能",
+      "type": "User Story",
+      "state": "Active",
+      "url": "https://dev.azure.com/org/project/_workitems/edit/12345",
+      "originalTeamName": "TeamA",
+      "isSuccess": true,
+      "errorMessage": null,
+      "resolutionStatus": "alreadyUserStoryOrAbove",
+      "userStory": {
+        "workItemId": 12345,
+        "title": "實作使用者登入功能",
+        "type": "User Story",
+        "state": "Active",
+        "url": "https://dev.azure.com/org/project/_workitems/edit/12345"
+      }
+    },
+    {
+      "workItemId": 67890,
+      "title": "修復登入頁面 CSS 問題",
+      "type": "Bug",
+      "state": "Resolved",
+      "url": "https://dev.azure.com/org/project/_workitems/edit/67890",
+      "originalTeamName": "TeamA",
+      "isSuccess": true,
+      "errorMessage": null,
+      "resolutionStatus": "foundViaRecursion",
+      "userStory": {
+        "workItemId": 12345,
+        "title": "實作使用者登入功能",
+        "type": "User Story",
+        "state": "Active",
+        "url": "https://dev.azure.com/org/project/_workitems/edit/12345"
+      }
+    }
+  ],
+  "totalCount": 2,
+  "alreadyUserStoryCount": 1,
+  "foundViaRecursionCount": 1,
+  "notFoundCount": 0,
+  "originalFetchFailedCount": 0
+}
+```
+
+## 解析結果狀態說明
+
+| 狀態 | 說明 | UserStory 欄位 |
+|------|------|----------------|
+| alreadyUserStoryOrAbove | 原始 Type 即為 User Story / Feature / Epic | 包含自身資訊 |
+| foundViaRecursion | 透過遞迴 Parent 找到 User Story 以上類型 | 包含找到的 User Story 資訊 |
+| notFound | 遞迴到頂層仍無法找到 User Story 以上類型 | null |
+| originalFetchFailed | 原始 Work Item 在先前步驟就無法取得 | null |

--- a/specs/001-get-user-story/research.md
+++ b/specs/001-get-user-story/research.md
@@ -1,0 +1,99 @@
+# Research: 取得 User Story 層級資訊
+
+**Feature Branch**: `001-get-user-story`
+**Date**: 2026-02-17
+
+## R-001: Azure DevOps API 取得 Parent 關係的方式
+
+**Decision**: 利用現有的 `$expand=all` API 呼叫，從回傳的 `relations` 陣列中解析 Parent Work Item ID。
+
+**Rationale**:
+- 現有的 `AzureDevOpsRepository.GetWorkItemAsync()` 已使用 `$expand=all` 參數，API 回應中已包含 `relations` 陣列
+- 目前的 `AzureDevOpsWorkItemResponse` 模型未定義 `relations` 欄位，導致該資料被忽略
+- 只需擴充回應模型與 Mapper，即可取得 Parent 資訊，無需額外 API 呼叫
+- Azure DevOps API 中 Parent 關係的 `rel` 值為 `System.LinkTypes.Hierarchy-Reverse`，URL 格式為 `https://dev.azure.com/{org}/{project}/_apis/wit/workitems/{parentId}`
+
+**Alternatives Considered**:
+1. **新增獨立的 API 呼叫 (`/relations` endpoint)**: 需額外 HTTP 請求，增加延遲，且 `$expand=all` 已包含此資訊
+2. **使用 WIQL 查詢 Parent**: 過度複雜，不符合 KISS 原則
+
+---
+
+## R-002: Work Item Type 階層分類
+
+**Decision**: 定義「User Story 以上」包含 `User Story`、`Feature`、`Epic` 三種類型，使用常數集合管理。
+
+**Rationale**:
+- Azure DevOps 預設 Agile 流程範本的 Work Item 階層為：Epic → Feature → User Story → Task / Bug
+- User Story 為需求追蹤的基本單位，Feature 與 Epic 為更高層級的需求分類
+- 以常數集合管理，便於未來擴充或調整
+- 未知類型視為「User Story 以下」，觸發遞迴查找以確保安全
+
+**Alternatives Considered**:
+1. **僅以 User Story 為目標**: 過於限制，可能遺失已在 Feature/Epic 層級的項目
+2. **動態偵測階層**: 過度工程化，Azure DevOps 的 Work Item 階層在同一專案中通常是固定的
+
+---
+
+## R-003: 新 Redis Key 命名
+
+**Decision**: 使用 `AzureDevOps:WorkItems:UserStories` 作為新的 Redis Key。
+
+**Rationale**:
+- 遵循現有命名慣例（`Namespace:Resource:SubResource`）
+- 與來源資料 `AzureDevOps:WorkItems` 在同一命名空間下，語意清晰
+- 表達此 Key 儲存的是經 User Story 解析後的 Work Item 資料
+
+**Alternatives Considered**:
+1. **`AzureDevOps:UserStories`**: 過於簡化，未表達與原始 Work Items 的關聯
+2. **`AzureDevOps:WorkItems:Resolved`**: 語意不夠明確
+
+---
+
+## R-004: 遞迴策略與防護機制
+
+**Decision**: 使用迭代式遞迴（while loop）搭配已訪問 ID 集合偵測循環參照，最大深度限制為 10 層。
+
+**Rationale**:
+- Azure DevOps 實務上 Work Item 階層深度很少超過 5 層（Epic → Feature → User Story → Task → Sub-task）
+- 10 層限制提供足夠的安全邊界
+- 使用 `HashSet<int>` 追蹤已訪問的 Work Item ID，有效偵測循環參照
+- 迭代式比遞迴式更好控制深度限制且避免 Stack Overflow
+
+**Alternatives Considered**:
+1. **無限制遞迴**: 風險過高，可能因資料異常導致無窮迴圈
+2. **僅限制 3 層**: 過於保守，可能在特殊流程中無法找到 User Story
+
+---
+
+## R-005: 新任務實作模式
+
+**Decision**: 建立 `GetUserStoryTask` 實作 `ITask` 介面，遵循現有 Task 模式（讀取 Redis → 處理 → 寫入 Redis）。
+
+**Rationale**:
+- 與現有 `FetchAzureDevOpsWorkItemsTask`、`BaseFilterPullRequestsByUserTask` 模式一致
+- Task 直接實作 `ITask`（不使用 Base Class），因為邏輯較為獨立
+- 依賴 `IRedisService`（讀取/寫入）和 `IAzureDevOpsRepository`（查詢 Parent）
+
+**Alternatives Considered**:
+1. **抽象為 Base Class**: 無其他類似任務需要共用邏輯，不符合 YAGNI
+2. **使用 MediatR Handler**: 現有專案雖參照 CQRS 但實際使用 Task Pattern，保持一致性
+
+---
+
+## R-006: 可重用元件清單
+
+以下現有元件將直接重用：
+
+| 元件 | 位置 | 用途 |
+|------|------|------|
+| `IRedisService` | Domain/Abstractions | Redis 讀寫操作 |
+| `IAzureDevOpsRepository` | Domain/Abstractions | 取得 Work Item 詳細資訊（含 Parent） |
+| `RedisKeys` | Common/Constants | Redis Key 常數管理 |
+| `JsonExtensions` | Common/Extensions | JSON 序列化/反序列化 |
+| `Result<T>` | Domain/Common | 錯誤處理模式 |
+| `WorkItemOutput` | Application/Common | 原始 Work Item 輸出模型（直接內嵌至新模型） |
+| `WorkItemFetchResult` | Application/Common | 作為讀取來源的資料結構 |
+| `TaskFactory` | Application/Tasks | 任務建立工廠（擴充新任務） |
+| `CommandLineParser` | Console/Parsers | CLI 參數解析（擴充新指令） |
+| `AzureDevOpsWorkItemMapper` | Infrastructure/AzureDevOps/Mappers | Work Item 映射（擴充 Parent ID 解析） |

--- a/specs/001-get-user-story/spec.md
+++ b/specs/001-get-user-story/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: 取得 User Story 層級資訊
+
+**Feature Branch**: `001-get-user-story`
+**Created**: 2026-02-17
+**Status**: Draft
+**Input**: User description: "新增一個 console arg，從 Redis 取得 Azure Work Item 資訊，遞迴找 Parent 至 User Story 層級並將結果存回 Redis"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 透過指令取得 User Story 層級資訊 (Priority: P1)
+
+身為發佈管理人員，我希望執行一個指令後，系統能自動將 Redis 中所有 Work Item 對應到其所屬的 User Story（或更高層級），並將結果存入新的 Redis Key，以便後續流程能以 User Story 為單位進行追蹤與彙整。
+
+**Why this priority**: 這是此功能的核心價值，沒有這個能力就無法實現 Work Item 到 User Story 的對應關係。
+
+**Independent Test**: 可透過在 Redis 中準備包含不同 Type（User Story、Task、Bug）的 Work Item 資料，執行指令後驗證新 Redis Key 中的內容是否正確對應到 User Story 層級。
+
+**Acceptance Scenarios**:
+
+1. **Given** Redis 中已有包含多個 Work Item 的資料（其中包含 User Story、Task、Bug 類型），**When** 使用者執行 `get-user-story` 指令，**Then** 系統讀取所有 Work Item 並依據類型進行處理，將結果寫入新的 Redis Key。
+
+2. **Given** Redis 中有一個 Type 為 Task 的 Work Item，且其 Parent 為 User Story，**When** 系統處理該 Work Item，**Then** 結果中包含原始 Work Item 資訊、對應的 User Story 資訊，以及標註「透過遞迴找到 User Story」的結果狀態。
+
+3. **Given** Redis 中有一個 Type 為 User Story 的 Work Item，**When** 系統處理該 Work Item，**Then** 結果中包含原始 Work Item 資訊，並標註「原始 Type 即為 User Story 以上」的結果狀態，無需進行遞迴查找。
+
+---
+
+### User Story 2 - 處理無法取得資訊的 Work Item (Priority: P2)
+
+身為發佈管理人員，我希望即使某些 Work Item 無法取得詳細資訊（例如原始取得就失敗），系統仍然保留這些項目在結果中，以便我能知道哪些項目需要手動處理。
+
+**Why this priority**: 確保資料完整性，避免遺失任何 Work Item 的追蹤，但屬於核心功能的補充。
+
+**Independent Test**: 可在 Redis 中準備包含取得失敗（IsSuccess = false）的 Work Item 資料，驗證這些項目是否出現在結果中並標註正確狀態。
+
+**Acceptance Scenarios**:
+
+1. **Given** Redis 中有一個原始就無法取得資訊的 Work Item（IsSuccess 為 false），**When** 系統處理該 Work Item，**Then** 結果中保留該 Work Item，並標註「原始的 Work Item 就無法取得資訊」的結果狀態。
+
+2. **Given** Redis 中有一個 Type 為 Task 的 Work Item，但遞迴查找 Parent 過程中某層級的 Work Item 無法取得，**When** 系統處理完成，**Then** 結果中標註「無法找到 User Story 以上的類型」的結果狀態。
+
+---
+
+### User Story 3 - 處理深層巢狀的 Work Item 階層 (Priority: P3)
+
+身為發佈管理人員，我希望系統能正確處理多層巢狀的 Work Item（例如 Sub-Task → Task → User Story），透過逐層遞迴找到最近的 User Story 或更高層級。
+
+**Why this priority**: 在實際使用中，Work Item 可能存在多層巢狀關係，需確保遞迴邏輯正確處理。
+
+**Independent Test**: 可準備多層巢狀的 Work Item（如 Bug → Task → User Story），驗證系統是否正確向上遞迴並找到 User Story。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一個 Bug 類型的 Work Item，其 Parent 為 Task，Task 的 Parent 為 User Story，**When** 系統遞迴查找，**Then** 最終找到 User Story，結果標註「透過遞迴找到 User Story」。
+
+2. **Given** 一個 Task 類型的 Work Item，其 Parent 為另一個 Task，而該 Task 沒有 Parent，**When** 系統遞迴查找，**Then** 無法找到 User Story，結果標註「無法找到 User Story 以上的類型」。
+
+---
+
+### Edge Cases
+
+- 當 Redis 中的 Work Item 來源資料為空時（無任何 Work Item），系統應正常完成並寫入空結果至新 Redis Key。
+- 當某個 Work Item 的 Parent 指向自己（循環參照），系統應能偵測並中止遞迴，避免無窮迴圈。
+- 當遞迴查找 Parent 的過程中遇到已刪除或無權限存取的 Work Item，系統應將該項目標註為「無法找到 User Story 以上的類型」。
+- 當所有 Work Item 都已經是 User Story 或更高層級，系統應正常處理而不進行任何遞迴查找。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系統 MUST 提供新的 console arg `get-user-story`，用於觸發 Work Item 到 User Story 層級對應的處理流程。
+- **FR-002**: 系統 MUST 從現有的 Redis Key 讀取 Work Item 資料作為輸入來源。
+- **FR-003**: 系統 MUST 判斷每個 Work Item 的 Type，若為 User Story、Feature、Epic 等層級，則直接標記為「已是 User Story 以上」。
+- **FR-004**: 系統 MUST 對 Type 為 User Story 以下（如 Task、Bug）的 Work Item，透過遞迴查找 Parent，直到找到 User Story 或更高層級的 Work Item。
+- **FR-005**: 系統 MUST 保留原始取得失敗（IsSuccess 為 false）的 Work Item，並標記為「原始的 Work Item 就無法取得資訊」。
+- **FR-006**: 系統 MUST 在遞迴查找過程中，若無法找到 User Story 以上層級（Parent 鏈結中斷或到達頂層），則標記為「無法找到 User Story 以上的類型」。
+- **FR-007**: 系統 MUST 將處理結果寫入新的 Redis Key，與原始 Work Item 資料分開儲存。
+- **FR-008**: 系統 MUST 在結果中保留原始 Work Item 的完整資訊（WorkItemId、Title、Type、State、Url、OriginalTeamName）。
+- **FR-009**: 系統 MUST 為每個結果項目標註解析結果狀態，共有四種狀態：(1) 原始 Type 即為 User Story 以上、(2) 透過遞迴找到 User Story 以上、(3) 無法找到 User Story 以上、(4) 原始 Work Item 無法取得資訊。
+- **FR-010**: 系統 MUST 在遞迴查找時偵測循環參照，避免無窮迴圈。
+- **FR-011**: 系統 MUST 在透過遞迴成功找到 User Story 時，一併記錄該 User Story 的資訊（WorkItemId、Title、Type 等）。
+
+### Key Entities
+
+- **WorkItemWithUserStory**: 代表一個經過 User Story 解析處理的 Work Item，包含原始 Work Item 資訊、解析結果狀態，以及找到的 User Story 資訊（若有）。
+- **解析結果狀態 (Resolution Status)**: 列舉值，表示 Work Item 與 User Story 的對應結果。四種狀態：原始即為 User Story 以上、透過遞迴找到、無法找到、原始資料取得失敗。
+- **UserStoryInfo**: 透過遞迴找到的 User Story 資訊，包含 WorkItemId、Title、Type 等基本屬性。
+
+## Assumptions
+
+- **Work Item Type 階層定義**: 「User Story 以上」包含 User Story、Feature、Epic 三種類型；「User Story 以下」包含 Task、Bug 等類型。若遇到未知類型，視為 User Story 以下進行遞迴查找。
+- **Parent 關係來源**: 透過 Azure DevOps API 取得 Work Item 的 Parent 關係（Relations 中的 Parent Link）。
+- **遞迴深度限制**: 合理假設遞迴深度不超過 10 層，超過時視為無法找到 User Story。
+- **新 Redis Key 命名**: 新的 Redis Key 將採用與現有 Key 一致的命名慣例。
+- **Console arg 命名**: 新增的指令名稱為 `get-user-story`，符合現有指令的 kebab-case 命名慣例。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 使用者執行 `get-user-story` 指令後，100% 的 Work Item（無論成功或失敗）都出現在結果中，不遺失任何項目。
+- **SC-002**: 所有 Type 為 User Story 以上的 Work Item，解析結果狀態正確標註為「原始即為 User Story 以上」。
+- **SC-003**: 所有 Type 為 Task 或 Bug 且有 Parent 為 User Story 的 Work Item，解析結果狀態正確標註為「透過遞迴找到」，且包含正確的 User Story 資訊。
+- **SC-004**: 所有原始取得失敗的 Work Item，解析結果狀態正確標註為「原始無法取得資訊」。
+- **SC-005**: 遇到循環參照時，系統不會進入無窮迴圈，能正常完成並回報結果。

--- a/specs/001-get-user-story/tasks.md
+++ b/specs/001-get-user-story/tasks.md
@@ -1,0 +1,238 @@
+# Tasks: 取得 User Story 層級資訊
+
+**Input**: Design documents from `/specs/001-get-user-story/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: 包含測試任務（Constitution 原則 I 強制 TDD）
+
+**Organization**: 任務依 User Story 分組，每個 Story 可獨立實作與測試。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可平行執行（不同檔案，無相依性）
+- **[Story]**: 所屬 User Story（US1, US2, US3）
+- 包含確切檔案路徑
+
+---
+
+## Phase 1: Setup（共用常數與列舉）
+
+**Purpose**: 建立所有 User Story 共用的常數、列舉與基礎模型
+
+- [ ] T001 [P] 新增 `AzureDevOpsUserStories` 常數至 `src/ReleaseKit.Common/Constants/RedisKeys.cs`，值為 `"AzureDevOps:WorkItems:UserStories"`
+- [ ] T002 [P] 建立 `WorkItemTypeConstants` 靜態類別於 `src/ReleaseKit.Common/Constants/WorkItemTypeConstants.cs`，定義 `UserStoryOrAboveTypes` 集合（HashSet：User Story、Feature、Epic）與 `MaxRecursionDepth = 10` 常數
+- [ ] T003 [P] 建立 `UserStoryResolutionStatus` 列舉於 `src/ReleaseKit.Application/Common/UserStoryResolutionStatus.cs`，包含四個值：AlreadyUserStoryOrAbove(0)、FoundViaRecursion(1)、NotFound(2)、OriginalFetchFailed(3)
+
+✅ 可建置 / ⚠️ 待補測試
+
+---
+
+## Phase 2: Foundational（基礎設施與領域模型擴充）
+
+**Purpose**: 擴充基礎設施層 API 回應模型與 Mapper，使系統能解析 Parent Work Item ID
+
+**⚠️ CRITICAL**: 所有 User Story 的遞迴查找均依賴此階段的 Parent ID 解析能力
+
+### Tests for Foundational
+
+> **NOTE: 先撰寫測試，確認測試失敗後再實作**
+
+- [ ] T004 [P] 撰寫 `AzureDevOpsWorkItemMapper` Parent ID 解析測試於 `tests/ReleaseKit.Infrastructure.Tests/AzureDevOps/Mappers/AzureDevOpsWorkItemMapperTests.cs`：測試含 Parent 關聯的回應可正確解析 ParentWorkItemId、無 Parent 關聯時 ParentWorkItemId 為 null、多個關聯中正確識別 Parent
+- [ ] T005 [P] 撰寫 `WorkItemTypeConstants` 測試於 `tests/ReleaseKit.Common.Tests/Constants/WorkItemTypeConstantsTests.cs`：驗證 UserStoryOrAboveTypes 包含 User Story、Feature、Epic，且不包含 Task、Bug
+
+### Implementation for Foundational
+
+- [ ] T006 [P] 建立 `AzureDevOpsRelationResponse` 記錄於 `src/ReleaseKit.Infrastructure/AzureDevOps/Models/AzureDevOpsRelationResponse.cs`，包含 Rel（string）、Url（string）、Attributes（Dictionary）欄位，使用 JsonPropertyName 標註
+- [ ] T007 [P] 擴充 `AzureDevOpsWorkItemResponse` 於 `src/ReleaseKit.Infrastructure/AzureDevOps/Models/AzureDevOpsWorkItemResponse.cs`，新增 `Relations` 欄位（List\<AzureDevOpsRelationResponse\>?）
+- [ ] T008 擴充 `WorkItem` 領域實體於 `src/ReleaseKit.Domain/Entities/WorkItem.cs`，新增 `ParentWorkItemId`（int?）欄位
+- [ ] T009 擴充 `AzureDevOpsWorkItemMapper.ToDomain()` 於 `src/ReleaseKit.Infrastructure/AzureDevOps/Mappers/AzureDevOpsWorkItemMapper.cs`，從 Relations 中找到 `System.LinkTypes.Hierarchy-Reverse` 類型的關聯，解析 URL 末尾數字為 ParentWorkItemId
+- [ ] T010 執行建置與測試驗證：確認 T004、T005 測試通過
+
+✅ 可建置 / ✅ 測試通過
+
+**Checkpoint**: 基礎設施層可正確解析 Parent Work Item ID，所有 User Story 的前置條件已就緒
+
+---
+
+## Phase 3: User Story 1 - 透過指令取得 User Story 層級資訊 (Priority: P1) 🎯 MVP
+
+**Goal**: 使用者執行 `get-user-story` 指令後，系統讀取 Redis 中的 Work Item 資料，判斷類型並遞迴找 Parent 至 User Story 層級，結果存入新 Redis Key
+
+**Independent Test**: 準備含 User Story、Task、Bug 類型的 Work Item 資料，驗證 AlreadyUserStoryOrAbove 與 FoundViaRecursion 兩種狀態正確標註
+
+### Tests for User Story 1
+
+> **NOTE: 先撰寫測試，確認測試失敗後再實作**
+
+- [ ] T011 [P] [US1] 撰寫 `GetUserStoryTask` 核心測試於 `tests/ReleaseKit.Application.Tests/Tasks/GetUserStoryTaskTests.cs`：(1) Redis 中有 User Story 類型的 Work Item → ResolutionStatus 為 AlreadyUserStoryOrAbove 且 UserStory 包含自身資訊；(2) Redis 中有 Task 類型的 Work Item 且其 Parent 為 User Story → ResolutionStatus 為 FoundViaRecursion 且 UserStory 包含 Parent 資訊；(3) 結果正確寫入 Redis Key `AzureDevOps:WorkItems:UserStories`
+- [ ] T012 [P] [US1] 撰寫 `CommandLineParser` 新指令測試於 `tests/ReleaseKit.Console.Tests/Parsers/CommandLineParserTests.cs`：測試 `get-user-story` 指令解析為 `TaskType.GetUserStory`、大小寫不敏感
+
+### Implementation for User Story 1
+
+- [ ] T013 [P] [US1] 建立 `UserStoryInfo` 記錄於 `src/ReleaseKit.Application/Common/UserStoryInfo.cs`，包含 WorkItemId（int）、Title（string）、Type（string）、State（string）、Url（string）
+- [ ] T014 [P] [US1] 建立 `UserStoryResolutionOutput` 記錄於 `src/ReleaseKit.Application/Common/UserStoryResolutionOutput.cs`，包含原始 WorkItemOutput 所有欄位 + ResolutionStatus + UserStory?
+- [ ] T015 [P] [US1] 建立 `UserStoryResolutionResult` 記錄於 `src/ReleaseKit.Application/Common/UserStoryResolutionResult.cs`，包含 Items 清單與統計欄位（TotalCount、AlreadyUserStoryCount、FoundViaRecursionCount、NotFoundCount、OriginalFetchFailedCount）
+- [ ] T016 [US1] 建立 `GetUserStoryTask` 於 `src/ReleaseKit.Application/Tasks/GetUserStoryTask.cs`，實作 `ITask` 介面：注入 ILogger、IRedisService、IAzureDevOpsRepository；ExecuteAsync 流程：(1) 從 Redis 讀取 WorkItemFetchResult、(2) 遍歷每個 WorkItemOutput、(3) 判斷 Type 是否為 UserStoryOrAbove、(4) 若不是則透過 API 遞迴查找 Parent、(5) 組裝 UserStoryResolutionResult、(6) 寫入新 Redis Key、(7) 輸出 JSON 至 stdout
+- [ ] T017 [US1] 新增 `GetUserStory` 至 `TaskType` 列舉於 `src/ReleaseKit.Application/Tasks/TaskType.cs`
+- [ ] T018 [US1] 新增 `get-user-story` 指令對應至 `src/ReleaseKit.Console/Parsers/CommandLineParser.cs` 的 `_taskMappings` 字典
+- [ ] T019 [US1] 新增 `TaskType.GetUserStory` case 至 `src/ReleaseKit.Application/Tasks/TaskFactory.cs` 的 `CreateTask` switch
+- [ ] T020 [US1] 註冊 `GetUserStoryTask` 至 DI 容器於 `src/ReleaseKit.Console/Extensions/ServiceCollectionExtensions.cs` 的 `AddApplicationServices` 方法
+- [ ] T021 [US1] 執行建置與測試驗證：確認 T011、T012 測試通過
+
+✅ 可建置 / ✅ 測試通過
+
+**Checkpoint**: User Story 1 完成，可執行 `get-user-story` 指令處理 AlreadyUserStoryOrAbove 與 FoundViaRecursion 兩種基本情境
+
+---
+
+## Phase 4: User Story 2 - 處理無法取得資訊的 Work Item (Priority: P2)
+
+**Goal**: 原始取得失敗的 Work Item 與遞迴查找失敗的 Work Item 都保留在結果中，並標註正確狀態
+
+**Independent Test**: 準備含 IsSuccess=false 的 Work Item 及遞迴中斷的情境，驗證 OriginalFetchFailed 與 NotFound 狀態
+
+### Tests for User Story 2
+
+> **NOTE: 先撰寫測試，確認測試失敗後再實作**
+
+- [ ] T022 [P] [US2] 撰寫測試於 `tests/ReleaseKit.Application.Tests/Tasks/GetUserStoryTaskTests.cs`：(1) IsSuccess=false 的 Work Item → ResolutionStatus 為 OriginalFetchFailed、UserStory 為 null；(2) Task 類型但 Parent 無法取得（API 回傳失敗）→ ResolutionStatus 為 NotFound；(3) Task 類型但無 Parent（ParentWorkItemId 為 null）→ ResolutionStatus 為 NotFound
+- [ ] T023 [P] [US2] 撰寫測試於 `tests/ReleaseKit.Application.Tests/Tasks/GetUserStoryTaskTests.cs`：驗證空 Redis 資料（無 Work Item）→ 正常完成並寫入空結果
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] 擴充 `GetUserStoryTask.ExecuteAsync()` 於 `src/ReleaseKit.Application/Tasks/GetUserStoryTask.cs`：在遍歷 WorkItemOutput 時，先判斷 IsSuccess 為 false 的項目直接標記為 OriginalFetchFailed；遞迴查找失敗時（API 錯誤、無 Parent）標記為 NotFound
+- [ ] T025 [US2] 執行建置與測試驗證：確認 T022、T023 測試通過
+
+✅ 可建置 / ✅ 測試通過
+
+**Checkpoint**: User Story 1 + 2 完成，系統可正確處理所有四種解析狀態
+
+---
+
+## Phase 5: User Story 3 - 處理深層巢狀的 Work Item 階層 (Priority: P3)
+
+**Goal**: 正確處理多層巢狀（如 Bug → Task → User Story）與循環參照偵測
+
+**Independent Test**: 準備多層巢狀 Work Item 與循環參照情境，驗證遞迴邏輯正確
+
+### Tests for User Story 3
+
+> **NOTE: 先撰寫測試，確認測試失敗後再實作**
+
+- [ ] T026 [P] [US3] 撰寫測試於 `tests/ReleaseKit.Application.Tests/Tasks/GetUserStoryTaskTests.cs`：(1) Bug → Task → User Story 三層遞迴 → ResolutionStatus 為 FoundViaRecursion 且 UserStory 為最終的 User Story；(2) Task → Task → 無 Parent 兩層遞迴失敗 → ResolutionStatus 為 NotFound
+- [ ] T027 [P] [US3] 撰寫測試於 `tests/ReleaseKit.Application.Tests/Tasks/GetUserStoryTaskTests.cs`：(1) 循環參照（Work Item A → B → A）→ ResolutionStatus 為 NotFound，不會無窮迴圈；(2) 超過最大遞迴深度（10 層）→ ResolutionStatus 為 NotFound
+
+### Implementation for User Story 3
+
+- [ ] T028 [US3] 擴充 `GetUserStoryTask` 遞迴邏輯於 `src/ReleaseKit.Application/Tasks/GetUserStoryTask.cs`：使用 HashSet\<int\> 追蹤已訪問 ID 偵測循環參照；使用計數器限制最大遞迴深度（WorkItemTypeConstants.MaxRecursionDepth）
+- [ ] T029 [US3] 執行建置與測試驗證：確認 T026、T027 測試通過
+
+✅ 可建置 / ✅ 測試通過
+
+**Checkpoint**: 所有 User Story 完成，系統可正確處理所有情境（基本解析、失敗處理、深層巢狀、循環偵測）
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 最終驗證與跨 User Story 的品質確認
+
+- [ ] T030 執行完整建置驗證：`dotnet build src/release-kit.sln`
+- [ ] T031 執行全部單元測試：`dotnet test` 確認所有測試通過
+- [ ] T032 驗證 quickstart.md 流程：確認 `get-user-story` 指令可正確執行
+
+✅ 可建置 / ✅ 測試通過
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: 無相依性，可立即開始
+- **Foundational (Phase 2)**: 依賴 Phase 1 完成（使用 WorkItemTypeConstants）
+- **User Stories (Phase 3+)**: 全部依賴 Phase 2 完成（需要 Parent ID 解析能力）
+  - US1、US2、US3 理論上可平行，但建議依優先序實作
+- **Polish (Phase 6)**: 依賴所有 User Story 完成
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Phase 2 完成後可開始，不依賴其他 Story
+- **User Story 2 (P2)**: Phase 2 完成後可開始，邏輯上擴充 US1 的 GetUserStoryTask（建議 US1 完成後實作）
+- **User Story 3 (P3)**: Phase 2 完成後可開始，邏輯上擴充 US1 的遞迴邏輯（建議 US1 完成後實作）
+
+### Within Each User Story
+
+- 測試 MUST 先撰寫且確認失敗（TDD Red phase）
+- DTO/Model 先於 Service/Task
+- 核心邏輯先於 CLI 整合
+- 完成後執行建置與測試驗證
+
+### Parallel Opportunities
+
+**Phase 1（全部可平行）**:
+- T001、T002、T003 → 不同檔案，無相依性
+
+**Phase 2（測試與部分實作可平行）**:
+- T004、T005 → 不同測試檔案
+- T006、T007 → 不同模型檔案
+
+**Phase 3 - US1（測試與 DTO 可平行）**:
+- T011、T012 → 不同測試檔案
+- T013、T014、T015 → 不同 DTO 檔案
+
+---
+
+## Parallel Example: Phase 1
+
+```bash
+# 三個獨立檔案，可同時執行：
+Task: "新增 AzureDevOpsUserStories 常數至 RedisKeys.cs"
+Task: "建立 WorkItemTypeConstants.cs"
+Task: "建立 UserStoryResolutionStatus.cs"
+```
+
+## Parallel Example: User Story 1
+
+```bash
+# 先平行撰寫測試：
+Task: "撰寫 GetUserStoryTask 核心測試"
+Task: "撰寫 CommandLineParser 新指令測試"
+
+# 再平行建立 DTO：
+Task: "建立 UserStoryInfo.cs"
+Task: "建立 UserStoryResolutionOutput.cs"
+Task: "建立 UserStoryResolutionResult.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup（T001-T003）
+2. Complete Phase 2: Foundational（T004-T010）
+3. Complete Phase 3: User Story 1（T011-T021）
+4. **STOP and VALIDATE**: 測試 `get-user-story` 指令處理 AlreadyUserStoryOrAbove 與 FoundViaRecursion
+5. 可交付 MVP
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → 基礎就緒
+2. + User Story 1 → MVP（基本解析功能）
+3. + User Story 2 → 完整錯誤處理
+4. + User Story 3 → 穩健的遞迴邏輯（循環偵測、深度限制）
+5. + Polish → 最終驗證
+
+---
+
+## Notes
+
+- [P] 標記 = 不同檔案、無相依性，可平行執行
+- [Story] 標記 = 對應 spec.md 的 User Story
+- Constitution 強制 TDD：每個 Phase 的測試必須先寫並確認失敗
+- 每個任務完成後標註建置與測試狀態
+- 所有註解使用繁體中文
+- 使用 JsonExtensions 進行 JSON 序列化/反序列化
+- 錯誤處理使用 Result Pattern，禁止 try-catch


### PR DESCRIPTION
包含 spec.md、plan.md、research.md、data-model.md、quickstart.md、 tasks.md、contracts/ 與 checklists/，定義從 Redis 讀取 Work Item 並遞迴查找 Parent User Story 的完整設計文件。