### PR TITLE
docs: 新增 001-redis-sheet-sync 功能規格與實作計畫

### DIFF
--- a/specs/001-redis-sheet-sync/checklists/requirements.md
+++ b/specs/001-redis-sheet-sync/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Redis → Google Sheet 批次同步
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items passed on first validation iteration
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`

--- a/specs/001-redis-sheet-sync/contracts/IGoogleSheetService.md
+++ b/specs/001-redis-sheet-sync/contracts/IGoogleSheetService.md
@@ -1,0 +1,50 @@
+# Contract: IGoogleSheetService
+
+**Feature**: 001-redis-sheet-sync
+**Layer**: Domain / Abstractions
+
+## 介面定義
+
+### IGoogleSheetService
+
+Google Sheet 資料存取服務介面，定義於 Domain 層，由 Infrastructure 層實作。
+
+#### 方法
+
+| 方法 | 回傳 | 說明 |
+|------|------|------|
+| `GetSheetIdByNameAsync(spreadsheetId, sheetName)` | `Task<int?>` | 透過工作表名稱取得 SheetId，找不到回傳 null |
+| `GetSheetDataAsync(spreadsheetId, range)` | `Task<IList<IList<object>>?>` | 讀取指定範圍的儲存格資料 |
+| `InsertRowsAsync(spreadsheetId, sheetId, rowIndex, count)` | `Task` | 在指定位置批次插入空白列 |
+| `UpdateCellsAsync(spreadsheetId, range, values)` | `Task` | 批次更新指定範圍的儲存格值（純文字） |
+| `UpdateCellWithHyperlinkAsync(spreadsheetId, sheetId, rowIndex, columnIndex, displayText, url)` | `Task` | 更新單一儲存格並設定超連結 |
+| `SortRangeAsync(spreadsheetId, sheetId, startRowIndex, endRowIndex, sortSpecs)` | `Task` | 對指定範圍依指定欄位排序 |
+| `BatchUpdateCellsAsync(spreadsheetId, updates)` | `Task` | 批次更新多個儲存格範圍 |
+
+#### 設計考量
+
+- **介面放置於 Domain 層**：遵循 DDD 依賴反轉原則，Application 層可直接使用此介面
+- **方法粒度**：每個方法對應一種 Google Sheets API 操作，保持單一職責
+- **批次操作**：`InsertRowsAsync` 與 `BatchUpdateCellsAsync` 支援批次操作，減少 API 呼叫次數
+- **超連結分離**：`UpdateCellWithHyperlinkAsync` 獨立於一般更新，因超連結需使用不同的 API 端點（FormulaValue vs StringValue）
+
+#### 排序規格
+
+`SortRangeAsync` 的 `sortSpecs` 參數：
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| ColumnIndex | int | 0-based 欄位索引 |
+| SortOrder | Ascending/Descending | 排序方向 |
+
+## 依賴關係
+
+```text
+Domain (IGoogleSheetService)
+    ↑
+Application (UpdateGoogleSheetsTask 使用介面)
+    ↑
+Infrastructure (GoogleSheetService 實作介面)
+    ↑
+Console (DI 註冊)
+```

--- a/specs/001-redis-sheet-sync/data-model.md
+++ b/specs/001-redis-sheet-sync/data-model.md
@@ -1,0 +1,116 @@
+# Data Model: Redis → Google Sheet 批次同步
+
+**Feature**: 001-redis-sheet-sync
+**Date**: 2026-02-24
+
+## 既有實體（不修改）
+
+### ConsolidatedReleaseResult
+
+代表整合後的 Release 資料集合，以專案名稱為 key 分組。
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| Projects | Dictionary\<string, List\<ConsolidatedReleaseEntry\>\> | 按專案名稱分組的資料 |
+
+### ConsolidatedReleaseEntry
+
+代表單筆整合的 Release 資料。
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| Title | string | User Story 標題（可能為空） |
+| WorkItemUrl | string | Work Item 連結（可能為空） |
+| WorkItemId | int | Work Item ID |
+| TeamDisplayName | string | 團隊顯示名稱 |
+| Authors | List\<ConsolidatedAuthorInfo\> | 作者清單 |
+| PullRequests | List\<ConsolidatedPrInfo\> | PR 清單 |
+| OriginalData | ConsolidatedOriginalData | 原始資料（同步時不使用） |
+
+### ConsolidatedAuthorInfo
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| AuthorName | string | 作者名稱 |
+
+### ConsolidatedPrInfo
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| Url | string | PR 網址 |
+
+## 新增概念模型（Application 層內部使用）
+
+### SheetProjectSegment（值物件概念）
+
+代表 Google Sheet 中一個專案區段的位置資訊。
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| ProjectName | string | 專案名稱 |
+| HeaderRowIndex | int | 專案表頭列的 0-based row index |
+| DataStartRowIndex | int | 資料起始列的 0-based row index（HeaderRowIndex + 1） |
+| DataEndRowIndex | int | 資料結束列的 0-based row index（下一個專案表頭列 - 1，或 Sheet 末尾） |
+
+### SyncAction（列舉概念）
+
+代表每筆資料的同步動作類型。
+
+| 值 | 說明 |
+|------|------|
+| Insert | 新增（UniqueKey 不存在於 Sheet） |
+| Update | 更新（UniqueKey 已存在於 Sheet） |
+
+## 資料流
+
+```text
+Redis (ReleaseData:Consolidated)
+    │
+    ▼ HashGetAsync + JsonExtensions.ToTypedObject
+    │
+ConsolidatedReleaseResult
+    │
+    ▼ 遍歷 Projects Dictionary
+    │
+┌───────────────────────────────────────┐
+│ 對每個 Project (key = projectName):   │
+│                                       │
+│  1. 計算 UniqueKey                    │
+│  2. 比對 Sheet UniqueKeyColumn        │
+│  3. 分類為 Insert 或 Update           │
+└───────────────────────────────────────┘
+    │
+    ▼
+┌───────────────────────────────────────┐
+│ 批次操作：                             │
+│  Step 1: 插入所有空白列                │
+│  Step 2: 填入新增資料 + 更新既有資料    │
+│  Step 3: 排序受影響的專案區段           │
+└───────────────────────────────────────┘
+    │
+    ▼
+Google Sheet (已更新)
+```
+
+## 欄位對應（由 ColumnMappingOptions 設定）
+
+| 設定 Key | 對應 Sheet 欄位 | 資料來源 | 格式 |
+|----------|----------------|---------|------|
+| RepositoryNameColumn | 如 Z | projectName（比對用，不寫入） | 純文字 |
+| FeatureColumn | 如 B | `VSTS{workItemId} - {title}` | HYPERLINK 公式 |
+| TeamColumn | 如 D | teamDisplayName | 純文字 |
+| AuthorsColumn | 如 E | authors[].authorName | 換行分隔，按 authorName 排序 |
+| PullRequestUrlsColumn | 如 X | pullRequests[].url | 換行分隔，按 url 排序 |
+| UniqueKeyColumn | 如 Y | `{workItemId}{projectName}` | 純文字 |
+| AutoSyncColumn | 如 F | 固定值 `TRUE` | 純文字 |
+
+## 排序規則
+
+專案區段內資料列排序（僅排序 headerRow+1 到 nextHeaderRow-1 的範圍）：
+
+| 優先序 | 欄位 | 方向 | 空白處理 |
+|--------|------|------|---------|
+| 1 | TeamColumn | 升序 | 排最後 |
+| 2 | AuthorsColumn | 升序 | 排最後 |
+| 3 | FeatureColumn | 升序 | 排最後 |
+| 4 | UniqueKeyColumn | 升序 | 排最後 |

--- a/specs/001-redis-sheet-sync/plan.md
+++ b/specs/001-redis-sheet-sync/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Redis → Google Sheet 批次同步
+
+**Branch**: `001-redis-sheet-sync` | **Date**: 2026-02-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-redis-sheet-sync/spec.md`
+
+## Summary
+
+實作 `UpdateGoogleSheetsTask`，將 Redis 中 `ReleaseData:Consolidated` 的整合資料批次同步至 Google Sheet。包含：修正 `ConsolidateReleaseDataTask` 無資料時拋錯行為、建立 `IGoogleSheetService` 介面與實作、實作完整的新增/更新/排序邏輯。
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9.0
+**Primary Dependencies**: Google.Apis.Sheets.v4（新增）、StackExchange.Redis（既有）、Microsoft.Extensions.*（既有）
+**Storage**: Redis（既有，讀取整合資料）、Google Sheets API v4（新增，寫入目標）
+**Testing**: xUnit 2.9.2 + Moq 4.20.72（既有）
+**Target Platform**: Console Application (Linux/Windows)
+**Project Type**: Clean Architecture 多層專案（Domain / Application / Infrastructure / Console）
+**Performance Goals**: 批次操作減少 API 呼叫次數，避免逐列操作
+**Constraints**: Google Sheets API 配額限制（每分鐘 60 次讀取、60 次寫入）；欄位範圍限制 A–Z
+**Scale/Scope**: 單次同步涉及數十至數百筆 Release 資料
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原則 | 狀態 | 說明 |
+|------|------|------|
+| I. TDD | ✅ | 所有新增邏輯遵循 Red-Green-Refactor |
+| II. DDD/CQRS | ✅ | IGoogleSheetService 定義於 Domain，實作於 Infrastructure；Task 為 Application 層 |
+| III. SOLID | ✅ | 單一職責（Task/Service 分離）、依賴反轉（介面注入）、介面隔離 |
+| IV. KISS | ✅ | 重用現有 ITask 模式、IRedisService、JsonExtensions |
+| V. 錯誤處理 | ✅ | 無 try-catch；無資料時回傳並結束，不拋例外 |
+| VI. 效能與快取 | ✅ | 批次讀取/寫入 Sheet 減少 API 呼叫；重用 IRedisService |
+| VII. 避免硬編碼 | ✅ | 欄位對應使用 ColumnMappingOptions 設定 |
+| VIII. 文件與註解 | ✅ | 繁體中文 XML Summary 註解 |
+| IX. JSON 序列化 | ✅ | 使用 JsonExtensions 反序列化 Redis 資料 |
+| X. Program.cs 整潔 | ✅ | 服務註冊於 ServiceCollectionExtensions |
+| XI. 單一類別檔案 | ✅ | 每個新類別/介面獨立檔案 |
+| XII. RESTful API | N/A | 本功能無 API 端點 |
+| XIII. 組態管理 | ✅ | GoogleSheetOptions 已設定於 appsettings.json |
+| XIV. 程式碼重用 | ✅ | 見下方可重用元件清單 |
+
+### 可重用元件清單
+
+| 元件 | 位置 | 用途 |
+|------|------|------|
+| `IRedisService` | Domain/Abstractions | 讀取 Redis 整合資料 |
+| `RedisService` | Infrastructure/Redis | IRedisService 實作 |
+| `RedisKeys` | Common/Constants | Redis 鍵值常數 |
+| `JsonExtensions` | Common/Extensions | JSON 反序列化 |
+| `ConsolidatedReleaseResult` | Application/Common | 整合資料模型 |
+| `ConsolidatedReleaseEntry` | Application/Common | 單筆資料模型 |
+| `ITask` | Domain/Abstractions | Task 介面 |
+| `TaskFactory` | Application/Tasks | Task 建立工廠 |
+| `GoogleSheetOptions` | Infrastructure/Configuration | Google Sheet 設定 |
+| `ColumnMappingOptions` | Infrastructure/Configuration | 欄位對應設定 |
+| `Result<T>` / `Error` | Domain/Common | 結構化錯誤處理 |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-redis-sheet-sync/
+├── plan.md              # 本檔案
+├── research.md          # Phase 0 研究結果
+├── data-model.md        # Phase 1 資料模型
+├── quickstart.md        # Phase 1 快速開始指南
+├── contracts/           # Phase 1 介面契約
+│   └── IGoogleSheetService.md
+└── tasks.md             # Phase 2 任務清單（由 /speckit.tasks 產生）
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── ReleaseKit.Domain/
+│   └── Abstractions/
+│       └── IGoogleSheetService.cs          # 新增：Google Sheet 服務介面
+│
+├── ReleaseKit.Application/
+│   ├── Tasks/
+│   │   ├── UpdateGoogleSheetsTask.cs       # 修改：實作同步邏輯
+│   │   └── ConsolidateReleaseDataTask.cs   # 修改：無資料時不拋錯
+│   └── Common/
+│       └── (既有模型，不修改)
+│
+├── ReleaseKit.Infrastructure/
+│   ├── GoogleSheets/
+│   │   └── GoogleSheetService.cs           # 新增：Google Sheets API 實作
+│   └── ReleaseKit.Infrastructure.csproj    # 修改：新增 Google.Apis.Sheets.v4
+│
+└── ReleaseKit.Console/
+    └── Extensions/
+        └── ServiceCollectionExtensions.cs  # 修改：註冊 IGoogleSheetService
+
+tests/
+├── ReleaseKit.Application.Tests/
+│   └── Tasks/
+│       ├── UpdateGoogleSheetsTaskTests.cs  # 新增：同步邏輯單元測試
+│       └── ConsolidateReleaseDataTaskTests.cs  # 修改：新增無資料情境測試
+└── ReleaseKit.Infrastructure.Tests/
+    └── GoogleSheets/
+        └── GoogleSheetServiceTests.cs      # 新增：Google Sheet 服務測試
+```
+
+**Structure Decision**: 沿用現有 Clean Architecture 分層結構，新增檔案放置於對應層級的既有目錄中。
+
+## Complexity Tracking
+
+> 無違反 Constitution 的項目，無需額外記錄。

--- a/specs/001-redis-sheet-sync/quickstart.md
+++ b/specs/001-redis-sheet-sync/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart: Redis → Google Sheet 批次同步
+
+**Feature**: 001-redis-sheet-sync
+**Date**: 2026-02-24
+
+## 前置條件
+
+1. Redis 中已有 `ReleaseData:Consolidated` 資料（由 `ConsolidateReleaseData` 任務產生）
+2. Google Sheet 已建立，且有正確的工作表名稱
+3. Google Service Account 已建立，且有工作表的編輯權限
+4. `appsettings.json` 已設定 `GoogleSheet` 區段
+
+## 設定範例
+
+```json
+{
+  "GoogleSheet": {
+    "SpreadsheetId": "your-spreadsheet-id",
+    "SheetName": "Release Notes",
+    "ServiceAccountCredentialPath": "/path/to/service-account.json",
+    "ColumnMapping": {
+      "RepositoryNameColumn": "Z",
+      "FeatureColumn": "B",
+      "TeamColumn": "D",
+      "AuthorsColumn": "E",
+      "PullRequestUrlsColumn": "X",
+      "UniqueKeyColumn": "Y",
+      "AutoSyncColumn": "F"
+    }
+  }
+}
+```
+
+## 執行方式
+
+```bash
+# 先執行整合任務（產生 Redis 資料）
+dotnet run --project src/ReleaseKit.Console -- consolidate-release-data
+
+# 再執行 Google Sheet 同步
+dotnet run --project src/ReleaseKit.Console -- update-google-sheets
+```
+
+## 行為說明
+
+### 正常流程
+
+1. 從 Redis 讀取 `ReleaseData:Consolidated` 整合資料
+2. 驗證 Google Sheet 可連線，取得 Sheet ID 與現有資料（A–Z）
+3. 比對 UniqueKey 欄位，分類為「新增」或「更新」
+4. 批次插入所有需要的空白列
+5. 填入新增資料（含超連結）並更新既有資料
+6. 對有變動的專案區段執行排序
+
+### 無資料情境
+
+- Redis 無整合資料 → 記錄日誌後正常結束
+- Google Sheet 無法連線 → 記錄日誌後正常結束
+- 所有資料皆已存在且無變更 → 僅更新 Authors/PR URLs 欄位
+
+### 錯誤情境
+
+- 欄位對應超過 Z 欄 → 拋出錯誤並終止
+
+## 開發與測試
+
+```bash
+# 建置
+dotnet build src/release-kit.sln
+
+# 執行所有測試
+dotnet test src/release-kit.sln
+
+# 僅執行 Application 層測試
+dotnet test tests/ReleaseKit.Application.Tests/
+```
+
+## 新增的 NuGet 套件
+
+| 套件 | 專案 | 用途 |
+|------|------|------|
+| Google.Apis.Sheets.v4 | ReleaseKit.Infrastructure | Google Sheets API 存取 |
+| Google.Apis.Auth | ReleaseKit.Infrastructure | Service Account 認證 |

--- a/specs/001-redis-sheet-sync/research.md
+++ b/specs/001-redis-sheet-sync/research.md
@@ -1,0 +1,98 @@
+# Research: Redis → Google Sheet 批次同步
+
+**Feature**: 001-redis-sheet-sync
+**Date**: 2026-02-24
+
+## R-001: Google Sheets API 整合方式
+
+**Decision**: 使用 `Google.Apis.Sheets.v4` NuGet 套件透過 Service Account 認證存取 Google Sheets
+
+**Rationale**:
+- Google.Apis.Sheets.v4 是 Google 官方 .NET SDK，長期維護且文件完整
+- Service Account 認證適合無使用者互動的 Console 應用程式
+- 專案已有 `ServiceAccountCredentialPath` 設定，符合既有架構
+- 使用 `Google.Apis.Auth` 搭配 `ServiceAccountCredential` 進行認證
+
+**Alternatives considered**:
+- 直接呼叫 REST API：需自行處理認證與序列化，工作量大且不必要
+- gRPC API：.NET SDK 已封裝，無需額外使用 gRPC
+
+## R-002: 批次操作策略
+
+**Decision**: 使用 Google Sheets `batchUpdate` API 進行批次列插入，使用 `values.batchUpdate` 進行批次儲存格更新
+
+**Rationale**:
+- `batchUpdate` 可在單次 API 呼叫中插入多列，減少 API 配額消耗
+- `values.batchUpdate` 可在單次呼叫中更新多個儲存格範圍
+- Google Sheets API 配額為每分鐘 60 次讀取/60 次寫入，批次操作可避免超出配額
+- 執行順序：先批次插入所有空白列 → 再批次填入/更新資料
+
+**Alternatives considered**:
+- 逐列操作：每筆資料一次 API 呼叫，效率低且易超出配額
+- Sheets API v3：已棄用，不建議使用
+
+## R-003: Sheet ID 動態取得
+
+**Decision**: 透過 Spreadsheets.Get API 取得所有工作表資訊，以 SheetName 比對取得 SheetId
+
+**Rationale**:
+- 規格要求透過 Sheet Name 動態取得 Sheet ID
+- `Spreadsheets.Get` 回傳的 `Spreadsheet.Sheets` 包含每個工作表的 `SheetProperties`（含 SheetId 與 Title）
+- 比對 `SheetProperties.Title` 與設定的 `SheetName` 即可取得 `SheetId`
+
+**Alternatives considered**:
+- 靜態設定 SheetId：不符合規格要求，且當工作表重建時 ID 會變更
+
+## R-004: 列插入位置計算
+
+**Decision**: 讀取 RepositoryNameColumn 全欄資料，建立專案區段索引表，再計算每筆新增資料的插入位置
+
+**Rationale**:
+- 需求區分「首筆之後」與「中間區段」兩種插入情境
+- 讀取整欄資料後可一次性建立所有專案的 row index 映射
+- 插入位置計算：
+  - 找到專案名稱所在的 row（headerRow）
+  - 找到下一個專案名稱的 row（nextHeaderRow）
+  - 新列插入於 headerRow + 1（首筆之後）或 nextHeaderRow 之前（中間區段）
+- 批次插入時需從最後一列往前插入，避免 row index 偏移
+
+**Alternatives considered**:
+- 逐筆插入後重新讀取 Sheet：API 呼叫次數倍增，效率極差
+
+## R-005: 排序實作策略
+
+**Decision**: 使用 Google Sheets `SortRange` batchUpdate 請求，在 Sheet 端直接排序
+
+**Rationale**:
+- Google Sheets API 的 `SortRangeRequest` 支援多欄排序，可直接指定排序欄位與方向
+- 在 Sheet 端排序避免讀取→排序→回寫的額外 API 呼叫
+- 排序範圍由專案區段的 headerRow 與 nextHeaderRow 決定
+
+**Alternatives considered**:
+- 讀取資料→本地排序→回寫：需額外 2 次 API 呼叫（讀取+寫入），且需處理超連結等格式保留
+
+## R-006: 超連結處理
+
+**Decision**: 使用 `UpdateCellsRequest` 搭配 `ExtendedValue.FormulaValue` 設定 `=HYPERLINK("url", "text")` 公式
+
+**Rationale**:
+- FeatureColumn 需要「VSTS{workItemId} - {title}」文字並帶有超連結
+- Google Sheets 的 `HYPERLINK` 函數可同時設定連結與顯示文字
+- 使用 FormulaValue 而非 StringValue 可保留超連結功能
+
+**Alternatives considered**:
+- 使用 TextFormatRun 設定連結：複雜度高且不直觀
+- 僅填入文字不加連結：不符合規格要求
+
+## R-007: ConsolidateReleaseDataTask 無資料處理修正
+
+**Decision**: 將 `InvalidOperationException` 替換為 `return`（正常結束），並記錄 Information 等級的日誌
+
+**Rationale**:
+- 規格要求無先行資料時不拋錯，直接結束
+- 使用 `ILogger.LogInformation` 記錄「無資料可整合」訊息，便於除錯
+- 符合 Constitution V.（錯誤處理策略）——不使用 try-catch，讓程式正常流程處理
+
+**Alternatives considered**:
+- 拋出自訂例外再由上層攔截：違反 Constitution 禁止 try-catch 的原則
+- 使用 Result Pattern 回傳：ITask.ExecuteAsync() 回傳 Task（void），修改介面影響範圍太大

--- a/specs/001-redis-sheet-sync/spec.md
+++ b/specs/001-redis-sheet-sync/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Redis → Google Sheet 批次同步
+
+**Feature Branch**: `001-redis-sheet-sync`
+**Created**: 2026-02-24
+**Status**: Draft
+**Input**: 將 Redis 中 `ReleaseData:Consolidated` 的資料批次新增或更新到 Google Sheet
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 批次同步整合資料至 Google Sheet (Priority: P1)
+
+身為 Release 管理人員，我希望執行程式時能自動將 Redis 中已整合的 Release 資料同步到 Google Sheet，讓我不需要手動逐筆輸入或更新資料，以便快速產出 Release Notes。
+
+**Why this priority**: 這是本功能的核心價值——自動化 Redis 到 Google Sheet 的資料同步流程，消除手動作業的時間成本與人為錯誤。
+
+**Independent Test**: 可透過準備 Redis 中的整合資料與空白或部分填入的 Google Sheet，執行同步後驗證 Sheet 中的資料是否正確新增與更新。
+
+**Acceptance Scenarios**:
+
+1. **Given** Redis 中有整合資料且 Google Sheet 可連線，**When** 執行同步，**Then** 新的資料列被新增到 Sheet 中正確的專案區段位置，既有資料的作者與 PR 網址欄位被更新
+2. **Given** Redis 中有多個專案的整合資料，**When** 執行同步，**Then** 每個專案的資料列被新增到對應專案區段，且各區段內依排序規則重新排列
+3. **Given** Redis 中有新資料需要新增，**When** 執行同步，**Then** 系統先插入所有需要的空白列，再依序填入新增資料與更新既有資料
+
+---
+
+### User Story 2 - 優雅處理無資料情境 (Priority: P2)
+
+身為 Release 管理人員，我希望當 Redis 中沒有整合資料時，程式能安靜地結束而不拋出錯誤，讓我知道「沒有資料需要同步」而不是看到錯誤訊息。
+
+**Why this priority**: 確保無資料時的使用體驗流暢，避免不必要的錯誤訊息造成混亂。這是基礎的錯誤處理改善。
+
+**Independent Test**: 可透過清空 Redis 中的整合資料後執行程式，驗證程式是否正常結束且無錯誤訊息。
+
+**Acceptance Scenarios**:
+
+1. **Given** Redis 中 `ReleaseData:Consolidated` 欄位不存在或為空，**When** 執行同步，**Then** 程式正常結束，不拋出任何例外
+2. **Given** Redis 中沒有先行資料（前置步驟未執行），**When** 執行同步，**Then** 程式正常結束，不拋出任何例外
+
+---
+
+### User Story 3 - Google Sheet 連線驗證 (Priority: P3)
+
+身為 Release 管理人員，我希望在開始同步前系統能先驗證 Google Sheet 的可用性，讓我在連線有問題時能提早得知，而不是在同步過程中才失敗。
+
+**Why this priority**: 前置驗證可避免部分同步導致資料不一致的風險，確保同步操作的原子性。
+
+**Independent Test**: 可透過提供無效的 Google Sheet 設定或中斷網路連線來驗證系統的錯誤處理行為。
+
+**Acceptance Scenarios**:
+
+1. **Given** Google Sheet 設定正確且可連線，**When** 執行同步前的驗證步驟，**Then** 驗證通過，程式繼續執行同步流程
+2. **Given** Google Sheet 無法連線或設定錯誤，**When** 執行同步前的驗證步驟，**Then** 程式正常結束，不繼續同步
+3. **Given** 設定檔中欄位對應超過 Z 欄，**When** 執行同步前的驗證步驟，**Then** 系統拋出錯誤告知欄位設定不合法
+
+---
+
+### Edge Cases
+
+- 當 Redis 整合資料中某筆 Work Item 的標題或 URL 為空時，仍應新增該列但對應欄位留空
+- 當同一 Work Item 跨多個專案時，每個專案會產生獨立的資料列（以 UniqueKey = `{workItemId}{projectName}` 區分）
+- 當 Google Sheet 中某個專案只有表頭列（RepositoryNameColumn 有值）而無任何資料列時，新增的資料列應插入在該表頭列之後
+- 當多筆新增資料屬於同一專案時，所有新增列應在同一批次中插入，避免逐筆插入導致 row index 偏移
+- 當 Redis 中的作者清單或 PR 網址清單為空時，對應欄位應留空
+- 當 Google Sheet 中已有的資料列其作者與 PR 網址與 Redis 資料相同時，仍應執行更新（覆寫），以確保資料一致性
+- 當 RepositoryNameColumn 中只有一個專案（僅一個非空值）時，該專案的資料範圍為該列之後到工作表末尾
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### 前置處理
+
+- **FR-001**: 系統 MUST 從 Redis 讀取 `ReleaseData:Consolidated` 欄位的整合資料
+- **FR-002**: 系統 MUST 在 Redis 中無整合資料（欄位不存在或值為空）時正常結束程式，不拋出例外
+- **FR-003**: 系統 MUST 修正目前「沒有先行資料就拋錯」的行為，改為正常結束程式
+
+#### Google Sheet 連線驗證
+
+- **FR-004**: 系統 MUST 透過 Sheet Name 動態取得 Sheet ID，而非使用靜態設定
+- **FR-005**: 系統 MUST 在同步前測試是否能取得 Google Sheet 及 Sheet 中 A–Z 的所有資料
+- **FR-006**: 系統 MUST 在無法取得 Google Sheet 資料時正常結束程式
+- **FR-007**: 系統 MUST 在設定檔中任何欄位對應超過 Z 欄時拋出錯誤
+
+#### 新增資料
+
+- **FR-008**: 系統 MUST 以 UniqueKey（`{workItemId}{projectName}`）比對 Sheet 中 UniqueKeyColumn 欄位，判斷資料是否已存在
+- **FR-009**: 系統 MUST 在 UniqueKey 不存在於 Sheet 時，將該筆資料視為「新增」
+- **FR-010**: 系統 MUST 先批次插入所有需要新增的空白列，再填入資料或更新既有資料
+- **FR-011**: 新增列的插入位置 MUST 依據 RepositoryNameColumn 判斷——插入到對應專案區段內
+- **FR-012**: 當新增資料的專案名稱出現在 RepositoryNameColumn 的第一筆時，新列 MUST 插入在該列之後
+- **FR-013**: 當新增資料的專案名稱出現在 RepositoryNameColumn 的中間區段時，新列 MUST 插入在該專案區段的下一列
+- **FR-014**: 新增列 MUST 填入以下欄位：
+  - FeatureColumn：`VSTS{workItemId} - {title}`，並加上超連結指向 workItemUrl
+  - TeamColumn：teamDisplayName
+  - AuthorsColumn：所有作者的 authorName，依 authorName 排序後以換行分隔
+  - PullRequestUrlsColumn：所有 PR 的 url，依 url 排序後以換行分隔
+  - UniqueKeyColumn：`{workItemId}{projectName}`
+  - AutoSyncColumn：固定值 `TRUE`
+
+#### 更新資料
+
+- **FR-015**: 系統 MUST 在 UniqueKey 存在於 Sheet 時，將該筆資料視為「更新」
+- **FR-016**: 更新時 MUST 僅更新 AuthorsColumn 與 PullRequestUrlsColumn 兩個欄位
+- **FR-017**: 更新的 AuthorsColumn MUST 依 authorName 排序後以換行分隔
+- **FR-018**: 更新的 PullRequestUrlsColumn MUST 依 url 排序後以換行分隔
+
+#### 排序
+
+- **FR-019**: 當有新增或更新發生時，系統 MUST 對該專案區段內的資料列重新排序
+- **FR-020**: 排序範圍 MUST 為同一專案中兩個相鄰 RepositoryNameColumn 之間的資料列（不含 RepositoryNameColumn 本身）
+- **FR-021**: 排序規則 MUST 依序為：TeamColumn → AuthorsColumn → FeatureColumn → UniqueKeyColumn
+- **FR-022**: 排序時空白值 MUST 排在最後
+
+### Key Entities
+
+- **ConsolidatedReleaseEntry**: 代表一筆已整合的 Release 資料，包含標題、Work Item 資訊、團隊名稱、作者清單、PR 清單
+- **ConsolidatedReleaseResult**: 代表按專案名稱分組的整合結果集合
+- **GoogleSheet 專案區段**: Sheet 中以 RepositoryNameColumn 為分界的資料區塊，每個區段代表一個專案的 Release 資料
+- **UniqueKey**: 由 Work Item ID 與專案名稱組合而成的唯一識別碼，用於判斷資料列是否已存在
+
+### Assumptions
+
+- 每個專案在 RepositoryNameColumn 中只會有一個表頭列（即 RepositoryNameColumn 中每個專案名稱只出現一次）
+- Google Sheet 的欄位範圍限制為 A–Z（26 欄），不支援 AA 以後的欄位
+- 所有欄位對應設定均在應用程式啟動時載入，同步過程中不會變更
+- 排序操作在 Sheet 中直接進行，以 Sheet 當前的資料為準
+- Redis 中的整合資料結構與 ConsolidatedReleaseResult 一致
+- AutoSyncColumn 的 `TRUE` 為文字字串值
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 執行同步後，Redis 中所有新增的整合資料 100% 正確出現在 Google Sheet 的對應專案區段中
+- **SC-002**: 執行同步後，所有既有資料的作者與 PR 網址欄位與 Redis 資料完全一致
+- **SC-003**: 當 Redis 無資料時，程式在不拋出任何例外的情況下正常結束
+- **SC-004**: 同步完成後，每個專案區段內的資料列均依指定排序規則正確排列
+- **SC-005**: 所有新增列的欄位值（Feature、Team、Authors、PR URLs、UniqueKey、AutoSync）均與 Redis 來源資料一致
+- **SC-006**: 欄位設定超過 Z 欄時，系統在同步前即拋出明確的錯誤訊息

--- a/specs/001-redis-sheet-sync/tasks.md
+++ b/specs/001-redis-sheet-sync/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: Redis → Google Sheet 批次同步
+
+**Input**: Design documents from `/specs/001-redis-sheet-sync/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: 依 Constitution I. TDD 原則，所有功能實作 MUST 遵循 Red-Green-Refactor 循環，因此包含測試任務。
+
+**Organization**: 任務按 User Story 優先級組織（P1 → P2 → P3），每個 Story 可獨立實作與測試。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可平行執行（不同檔案、無相依性）
+- **[Story]**: 所屬 User Story（US1, US2, US3）
+- 包含完整檔案路徑
+
+---
+
+## Phase 1: Setup（共享基礎設施）
+
+**Purpose**: 安裝相依套件、建立核心介面
+
+- [ ] T001 新增 Google.Apis.Sheets.v4 與 Google.Apis.Auth NuGet 套件至 `src/ReleaseKit.Infrastructure/ReleaseKit.Infrastructure.csproj`
+- [ ] T002 建立 `IGoogleSheetService` 介面於 `src/ReleaseKit.Domain/Abstractions/IGoogleSheetService.cs`，包含 `GetSheetIdByNameAsync`、`GetSheetDataAsync`、`InsertRowsAsync`、`UpdateCellsAsync`、`UpdateCellWithHyperlinkAsync`、`SortRangeAsync`、`BatchUpdateCellsAsync` 七個方法，依 `contracts/IGoogleSheetService.md` 定義的簽章實作
+- [ ] T003 驗證建置通過：執行 `dotnet build src/release-kit.sln` 確認無編譯錯誤
+
+---
+
+## Phase 2: Foundational（阻塞性前置任務）
+
+**Purpose**: 實作 Google Sheets API 基礎服務，所有 User Story 均依賴此階段完成
+
+**⚠️ CRITICAL**: 此階段完成前不可開始任何 User Story 任務
+
+### Tests
+
+- [ ] T004 撰寫 `GoogleSheetService` 單元測試於 `tests/ReleaseKit.Infrastructure.Tests/GoogleSheets/GoogleSheetServiceTests.cs`：測試 `GetSheetIdByNameAsync` 回傳正確 SheetId 及找不到時回傳 null、`GetSheetDataAsync` 回傳正確資料、`InsertRowsAsync` 呼叫正確 API 參數、`UpdateCellsAsync` 與 `BatchUpdateCellsAsync` 批次更新行為、`UpdateCellWithHyperlinkAsync` 使用 HYPERLINK 公式、`SortRangeAsync` 排序參數正確
+
+### Implementation
+
+- [ ] T005 實作 `GoogleSheetService` 於 `src/ReleaseKit.Infrastructure/GoogleSheets/GoogleSheetService.cs`：使用 `ServiceAccountCredential` 認證、實作 `IGoogleSheetService` 全部七個方法。`GetSheetIdByNameAsync` 透過 `Spreadsheets.Get` 比對 SheetName 取得 SheetId；`InsertRowsAsync` 使用 `InsertDimensionRequest`；`UpdateCellWithHyperlinkAsync` 使用 `FormulaValue` 設定 `=HYPERLINK()`；`SortRangeAsync` 使用 `SortRangeRequest`
+- [ ] T006 於 `src/ReleaseKit.Console/Extensions/ServiceCollectionExtensions.cs` 註冊 `IGoogleSheetService` → `GoogleSheetService` 為 Singleton，並確認 `GoogleSheetOptions` 的 `Configure` 已含 `ColumnMapping` 子區段
+- [ ] T007 驗證建置與測試通過：執行 `dotnet build src/release-kit.sln && dotnet test src/release-kit.sln`
+
+**Checkpoint**: 基礎設施就緒——可開始 User Story 實作 ✅ 可建置 / ✅ 測試通過
+
+---
+
+## Phase 3: User Story 1 — 批次同步整合資料至 Google Sheet (Priority: P1) 🎯 MVP
+
+**Goal**: 從 Redis 讀取整合資料，批次新增或更新到 Google Sheet 對應專案區段，並對受影響區段重新排序
+
+**Independent Test**: 準備 Redis 整合資料與含有部分專案資料的 Google Sheet，執行同步後驗證新增列位置正確、更新列欄位正確、排序正確
+
+### Tests for User Story 1
+
+> **遵循 TDD：先撰寫測試 → 確認失敗 → 再實作**
+
+- [ ] T008 [P] [US1] 撰寫測試：讀取 Redis 整合資料並反序列化為 `ConsolidatedReleaseResult`；驗證呼叫 `IRedisService.HashGetAsync(ReleaseDataHash, Consolidated)` 並使用 `JsonExtensions.ToTypedObject` 反序列化，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T009 [P] [US1] 撰寫測試：從 Sheet RepositoryNameColumn 建立專案區段索引（`SheetProjectSegment` 列表）；驗證 HeaderRowIndex、DataStartRowIndex、DataEndRowIndex 正確計算，包含僅一個專案（資料範圍到 Sheet 末尾）與多個專案（相鄰 header 之間）情境，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T010 [P] [US1] 撰寫測試：以 UniqueKey（`{workItemId}{projectName}`）比對 Sheet UniqueKeyColumn，分類為 Insert 或 Update；驗證新 UniqueKey 判定為 Insert、既有 UniqueKey 判定為 Update，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T011 [P] [US1] 撰寫測試：批次插入空白列的位置計算；驗證首筆專案的新列插入在 headerRow 之後、中間區段專案的新列插入在 nextHeaderRow 之前、僅有表頭無資料的專案插入在 headerRow+1；驗證多筆同專案新增時位置不重疊；驗證從最後一列往前插入以避免 index 偏移，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T012 [P] [US1] 撰寫測試：新增列資料填入格式；驗證 FeatureColumn 為 `VSTS{workItemId} - {title}` 含超連結、TeamColumn 為 teamDisplayName、AuthorsColumn 為依 authorName 排序後換行分隔、PullRequestUrlsColumn 為依 url 排序後換行分隔、UniqueKeyColumn 為 `{workItemId}{projectName}`、AutoSyncColumn 為 `TRUE`；驗證空 Authors/PullRequests 時欄位留空，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T013 [P] [US1] 撰寫測試：更新既有列僅更新 AuthorsColumn 與 PullRequestUrlsColumn；驗證其他欄位不被修改、Authors 依 authorName 排序後換行分隔、PRUrls 依 url 排序後換行分隔，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T014 [P] [US1] 撰寫測試：專案區段排序；驗證排序範圍為 headerRow+1 到 nextHeaderRow-1、排序規則依序為 TeamColumn → AuthorsColumn → FeatureColumn → UniqueKeyColumn、空白值排最後，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T015 [US1] 撰寫測試：完整 ExecuteAsync 端對端流程；驗證執行順序為「讀取 Redis → 讀取 Sheet → 分類 → 批次插入空白列 → 填入新增資料 + 更新既有資料 → 排序」；驗證多專案情境各區段獨立處理，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] 實作 `UpdateGoogleSheetsTask` 建構子注入 `IRedisService`、`IGoogleSheetService`、`IOptions<GoogleSheetOptions>`、`ILogger<UpdateGoogleSheetsTask>` 於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`，並更新 DI 註冊確保新增依賴可正確解析
+- [ ] T017 [US1] 實作 Redis 整合資料讀取：呼叫 `HashGetAsync(RedisKeys.ReleaseDataHash, RedisKeys.Fields.Consolidated)` 並以 `JsonExtensions.ToTypedObject<ConsolidatedReleaseResult>` 反序列化，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T018 [US1] 實作 Sheet 資料讀取與專案區段索引建構：讀取 A:Z 範圍資料、解析 RepositoryNameColumn 建立 `SheetProjectSegment` 列表、解析 UniqueKeyColumn 建立既有 UniqueKey 集合，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T019 [US1] 實作 Insert/Update 分類邏輯：遍歷 `ConsolidatedReleaseResult.Projects`，以 `{workItemId}{projectName}` 為 UniqueKey 比對 Sheet 既有資料，分類為 Insert 或 Update，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T020 [US1] 實作批次空白列插入：按專案分組計算每筆 Insert 的插入位置，從最後一列往前執行 `InsertRowsAsync` 避免 index 偏移，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T021 [US1] 實作新增列資料填入：使用 `UpdateCellWithHyperlinkAsync` 填入 FeatureColumn（`=HYPERLINK("workItemUrl","VSTS{id} - {title}")`）、使用 `BatchUpdateCellsAsync` 填入 TeamColumn、AuthorsColumn（排序+換行）、PullRequestUrlsColumn（排序+換行）、UniqueKeyColumn、AutoSyncColumn（`TRUE`），於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T022 [US1] 實作既有列更新：找到 UniqueKey 對應的 row index，僅更新 AuthorsColumn 與 PullRequestUrlsColumn，使用 `BatchUpdateCellsAsync` 批次更新，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T023 [US1] 實作專案區段排序：對每個有新增或更新的專案，呼叫 `SortRangeAsync` 以 TeamColumn → AuthorsColumn → FeatureColumn → UniqueKeyColumn 排序，排序範圍為 headerRow+1 至 nextHeaderRow-1，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T024 [US1] 驗證建置與測試通過：執行 `dotnet build src/release-kit.sln && dotnet test src/release-kit.sln`
+
+**Checkpoint**: User Story 1 完成，可獨立執行 Redis → Sheet 同步 ✅ 可建置 / ✅ 測試通過
+
+---
+
+## Phase 4: User Story 2 — 優雅處理無資料情境 (Priority: P2)
+
+**Goal**: 當 Redis 無整合資料或無先行資料時，程式正常結束不拋例外
+
+**Independent Test**: 清空 Redis 整合資料後執行程式，確認程式正常結束無例外
+
+### Tests for User Story 2
+
+- [ ] T025 [P] [US2] 撰寫測試：`UpdateGoogleSheetsTask` 當 Redis `ReleaseData:Consolidated` 不存在或為空字串時，`ExecuteAsync` 正常結束不拋例外、記錄 Information 日誌，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T026 [P] [US2] 撰寫測試：`ConsolidateReleaseDataTask` 當 Bitbucket 與 GitLab PR 資料均不存在時，`ExecuteAsync` 正常結束不拋 `InvalidOperationException`、記錄 Information 日誌，於 `tests/ReleaseKit.Application.Tests/Tasks/ConsolidateReleaseDataTaskTests.cs`
+- [ ] T027 [P] [US2] 撰寫測試：`ConsolidateReleaseDataTask` 當 Azure DevOps Work Item 資料不存在時，`ExecuteAsync` 正常結束不拋 `InvalidOperationException`、記錄 Information 日誌，於 `tests/ReleaseKit.Application.Tests/Tasks/ConsolidateReleaseDataTaskTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T028 [US2] 修正 `ConsolidateReleaseDataTask.ExecuteAsync`：將「Bitbucket 與 GitLab PR 資料均不存在時拋出 `InvalidOperationException`」改為記錄 `LogInformation("沒有 PR 資料可供整合")` 後 `return`，於 `src/ReleaseKit.Application/Tasks/ConsolidateReleaseDataTask.cs`
+- [ ] T029 [US2] 修正 `ConsolidateReleaseDataTask.ExecuteAsync`：將「Azure DevOps Work Item 資料不存在時拋出 `InvalidOperationException`」改為記錄 `LogInformation("沒有 Work Item 資料可供整合")` 後 `return`，於 `src/ReleaseKit.Application/Tasks/ConsolidateReleaseDataTask.cs`
+- [ ] T030 [US2] 實作 `UpdateGoogleSheetsTask.ExecuteAsync` 無資料早期結束：Redis 回傳 null 或空字串時記錄 `LogInformation("Redis 中沒有整合資料，結束同步")` 後 `return`，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T031 [US2] 驗證建置與測試通過：執行 `dotnet build src/release-kit.sln && dotnet test src/release-kit.sln`
+
+**Checkpoint**: User Story 2 完成，無資料情境不再拋例外 ✅ 可建置 / ✅ 測試通過
+
+---
+
+## Phase 5: User Story 3 — Google Sheet 連線驗證 (Priority: P3)
+
+**Goal**: 同步前驗證 Google Sheet 可用性與欄位設定合法性，不合法時提早結束或拋錯
+
+**Independent Test**: 提供無效 Sheet 設定或超過 Z 欄的設定，驗證系統的錯誤處理行為
+
+### Tests for User Story 3
+
+- [ ] T032 [P] [US3] 撰寫測試：ColumnMappingOptions 欄位驗證，任何欄位值超過 `Z`（如 `AA`、`AB`）時拋出 `InvalidOperationException`；所有欄位均在 A–Z 範圍內時驗證通過，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T033 [P] [US3] 撰寫測試：`GetSheetIdByNameAsync` 回傳 null（Sheet Name 找不到）時，`ExecuteAsync` 正常結束不繼續同步、記錄日誌，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+- [ ] T034 [P] [US3] 撰寫測試：`GetSheetDataAsync` 回傳 null（無法讀取 Sheet 資料）時，`ExecuteAsync` 正常結束不繼續同步、記錄日誌，於 `tests/ReleaseKit.Application.Tests/Tasks/UpdateGoogleSheetsTaskTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T035 [US3] 實作欄位範圍驗證：在 `UpdateGoogleSheetsTask.ExecuteAsync` 開頭驗證 `ColumnMappingOptions` 所有欄位均為單一字母 A–Z，任何欄位超出範圍時拋出 `InvalidOperationException` 含明確錯誤訊息（如「欄位 RepositoryNameColumn 的值 'AA' 超出 A–Z 範圍」），於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T036 [US3] 實作 Sheet 連線驗證：透過 `GetSheetIdByNameAsync` 動態取得 SheetId，回傳 null 時記錄 `LogWarning` 後 `return`；取得 SheetId 後讀取 A:Z 範圍資料，回傳 null 時記錄 `LogWarning` 後 `return`，於 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T037 [US3] 驗證建置與測試通過：執行 `dotnet build src/release-kit.sln && dotnet test src/release-kit.sln`
+
+**Checkpoint**: User Story 3 完成，同步前預先驗證設定與連線 ✅ 可建置 / ✅ 測試通過
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 最終驗證、文件更新與程式碼品質確認
+
+- [ ] T038 [P] 確認所有公開類別與方法均有繁體中文 XML Summary 註解，於 `src/ReleaseKit.Domain/Abstractions/IGoogleSheetService.cs` 與 `src/ReleaseKit.Infrastructure/GoogleSheets/GoogleSheetService.cs` 與 `src/ReleaseKit.Application/Tasks/UpdateGoogleSheetsTask.cs`
+- [ ] T039 [P] 確認 `appsettings.json` 包含完整 `GoogleSheet` 區段設定（含 ColumnMapping 子區段），對照 `quickstart.md` 範例，於 `src/ReleaseKit.Console/appsettings.json`
+- [ ] T040 最終驗證：執行 `dotnet build src/release-kit.sln && dotnet test src/release-kit.sln` 確認全部建置成功且所有測試通過
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: 無相依性 — 可立即開始
+- **Foundational (Phase 2)**: 相依於 Phase 1 完成 — **阻塞**所有 User Story
+- **US1 (Phase 3)**: 相依於 Phase 2 完成
+- **US2 (Phase 4)**: 相依於 Phase 2 完成（`ConsolidateReleaseDataTask` 修正不需 Phase 3）
+- **US3 (Phase 5)**: 相依於 Phase 2 完成
+- **Polish (Phase 6)**: 相依於所有 User Story 完成
+
+### User Story Dependencies
+
+- **US1 (P1)**: Phase 2 完成後可開始 — 不依賴其他 Story
+- **US2 (P2)**: Phase 2 完成後可開始 — 不依賴其他 Story（`ConsolidateReleaseDataTask` 修正獨立於 US1）
+- **US3 (P3)**: Phase 2 完成後可開始 — 不依賴其他 Story
+
+> 💡 US1、US2、US3 可平行開發，但建議按優先序（P1 → P2 → P3）依序完成，因 US1 的 `ExecuteAsync` 結構會影響 US2 和 US3 的插入位置。
+
+### Within Each User Story
+
+- 測試 MUST 先撰寫並確認失敗，再開始實作
+- 每個 Checkpoint 執行建置與測試驗證
+
+### Parallel Opportunities
+
+- Phase 1: T002 可與 T001 平行（不同檔案）
+- Phase 2: T004 撰寫測試時可與 Phase 1 收尾平行
+- Phase 3: T008–T014 所有測試任務可平行撰寫
+- Phase 4: T025–T027 所有測試任務可平行撰寫
+- Phase 5: T032–T034 所有測試任務可平行撰寫
+- Phase 6: T038 與 T039 可平行
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# 可同時啟動所有 US1 測試撰寫任務（不同測試案例、同一檔案但不衝突）：
+T008: 測試 Redis 資料讀取與反序列化
+T009: 測試專案區段索引建構
+T010: 測試 UniqueKey Insert/Update 分類
+T011: 測試批次列插入位置計算
+T012: 測試新增列資料填入格式
+T013: 測試既有列更新範圍
+T014: 測試專案區段排序
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. 完成 Phase 1: Setup（T001–T003）
+2. 完成 Phase 2: Foundational（T004–T007）
+3. 完成 Phase 3: User Story 1（T008–T024）
+4. **STOP and VALIDATE**: 獨立測試 US1 — 確認 Redis 資料可正確同步至 Sheet
+5. 若可部署則發佈 MVP
+
+### Incremental Delivery
+
+1. Setup + Foundational → 基礎設施就緒
+2. + User Story 1 → 核心同步功能（**MVP** 🎯）
+3. + User Story 2 → 無資料情境優雅處理
+4. + User Story 3 → 同步前驗證（完整功能）
+5. + Polish → 文件與品質確認（正式發佈）
+
+---
+
+## Notes
+
+- [P] 任務 = 不同檔案或無相依性，可平行
+- [Story] 標籤對應 spec.md 的 User Story 編號
+- 每個 User Story 完成後獨立可測試
+- 遵循 TDD：先寫測試確認失敗，再實作
+- 每個 Checkpoint 後執行 `dotnet build && dotnet test` 驗證


### PR DESCRIPTION
- spec.md: 功能規格（3 個 User Story、22 項功能需求）
- plan.md: 實作計畫（技Constitution Check）
- research.md: 技術研究（7 項決策：Google Sheets API、批次操作、排序策略等）
- data-model.md: 資料模型（既有實體與新增概念模型）
- contracts/IGoogleSheetService.md: 服務介面契約（7 個方法）
- quickstart.md: 快速開始指南
- tasks.md: 實作任務清單（40 項任務、6 個階段）
- checklists/requirements.md: 規格品質檢查清單

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>