### PR TITLE
refactor: 使用 ReleaseBranchHelper 驗證 release branch yyyyMMdd 格式

### DIFF
--- a/src/ReleaseKit.Application/Tasks/BaseFetchReleaseBranchTask.cs
+++ b/src/ReleaseKit.Application/Tasks/BaseFetchReleaseBranchTask.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using ReleaseKit.Common.Configuration;
 using ReleaseKit.Common.Extensions;
 using ReleaseKit.Domain.Abstractions;
+using ReleaseKit.Domain.Helpers;
 
 namespace ReleaseKit.Application.Tasks;
 
@@ -92,18 +93,30 @@ public abstract class BaseFetchReleaseBranchTask<TOptions, TProjectOptions> : IT
 
             if (result.IsSuccess && result.Value != null && result.Value.Count > 0)
             {
-                // 成功且有分支：取最新分支（字母排序最大的）
-                var latestBranch = result.Value.OrderByDescending(b => b).First();
-                _logger.LogInformation("專案 {ProjectPath} 最新 Release Branch: {Branch}", project.ProjectPath, latestBranch);
+                // 過濾出符合 release/yyyyMMdd 格式的分支並依日期降冪排序
+                var validBranches = ReleaseBranchHelper.SortReleaseBranchesDescending(result.Value);
 
-                // 加入對應分支名稱的分組
-                if (!branchGroups.ContainsKey(latestBranch))
+                if (validBranches.Count > 0)
                 {
-                    branchGroups[latestBranch] = new List<string>();
-                }
-                branchGroups[latestBranch].Add(project.ProjectPath);
+                    var latestBranch = validBranches[0];
+                    _logger.LogInformation("專案 {ProjectPath} 最新 Release Branch: {Branch}", project.ProjectPath, latestBranch);
 
-                successCount++;
+                    // 加入對應分支名稱的分組
+                    if (!branchGroups.ContainsKey(latestBranch))
+                    {
+                        branchGroups[latestBranch] = new List<string>();
+                    }
+                    branchGroups[latestBranch].Add(project.ProjectPath);
+
+                    successCount++;
+                }
+                else
+                {
+                    // 有分支但無符合 release/yyyyMMdd 格式的分支
+                    _logger.LogWarning("專案 {ProjectPath} 無符合 release/yyyyMMdd 格式的 Release Branch", project.ProjectPath);
+                    notFoundProjects.Add(project.ProjectPath);
+                    failureCount++;
+                }
             }
             else
             {
@@ -129,7 +142,7 @@ public abstract class BaseFetchReleaseBranchTask<TOptions, TProjectOptions> : IT
                     return (0, "");
                 
                 // release/yyyyMMdd 格式的 branch 排前面（優先度 2），並依日期降冪排序
-                if (kvp.Key.StartsWith("release/", StringComparison.OrdinalIgnoreCase) && kvp.Key.Length == 16 && kvp.Key.Substring(8).All(char.IsDigit))
+                if (ReleaseBranchHelper.IsReleaseBranch(kvp.Key))
                     return (2, kvp.Key);
                 
                 // 其他 branch（優先度 1），隨便排

--- a/tests/ReleaseKit.Application.Tests/Tasks/FetchBitbucketReleaseBranchTaskTests.cs
+++ b/tests/ReleaseKit.Application.Tests/Tasks/FetchBitbucketReleaseBranchTaskTests.cs
@@ -633,24 +633,25 @@ public class FetchBitbucketReleaseBranchTaskTests
         // Act
         await task.ExecuteAsync();
 
-        // Assert - 驗證排序：標準 release/yyyyMMdd 在前面且降冪排序，非標準的在中間，NotFound 最後
+        // Assert - 驗證：標準 release/yyyyMMdd 降冪排序在前，非標準格式歸入 NotFound
         Assert.NotNull(savedJson);
         var indexOf20260210 = savedJson.IndexOf("release/20260210", StringComparison.Ordinal);
         var indexOf20260115 = savedJson.IndexOf("release/20260115", StringComparison.Ordinal);
-        var indexOfV2 = savedJson.IndexOf("release/v2.0", StringComparison.Ordinal);
-        var indexOfHotfix = savedJson.IndexOf("release/hotfix", StringComparison.Ordinal);
         var indexOfNotFound = savedJson.IndexOf("NotFound", StringComparison.Ordinal);
 
         // 標準格式的 branch 應該在最前面且降冪排序
         Assert.True(indexOf20260210 < indexOf20260115, "release/20260210 應該在 release/20260115 之前");
-        
-        // 標準格式應該在非標準格式之前
-        Assert.True(indexOf20260115 < indexOfV2, "標準格式應該在非標準格式之前");
-        Assert.True(indexOf20260115 < indexOfHotfix, "標準格式應該在非標準格式之前");
-        
-        // NotFound 應該在最後
-        Assert.True(indexOfV2 < indexOfNotFound, "非標準 branch 應該在 NotFound 之前");
-        Assert.True(indexOfHotfix < indexOfNotFound, "非標準 branch 應該在 NotFound 之前");
+
+        // 非標準格式（release/v2.0、release/hotfix）不應出現為獨立分組
+        Assert.Equal(-1, savedJson.IndexOf("release/v2.0", StringComparison.Ordinal));
+        Assert.Equal(-1, savedJson.IndexOf("release/hotfix", StringComparison.Ordinal));
+
+        // NotFound 應包含非標準格式的專案與無分支的專案
+        Assert.True(indexOfNotFound > 0, "應有 NotFound 分組");
+        Assert.True(indexOf20260115 < indexOfNotFound, "標準格式應該在 NotFound 之前");
+        Assert.Contains("workspace/project-custom1", savedJson);
+        Assert.Contains("workspace/project-custom2", savedJson);
+        Assert.Contains("workspace/project-none", savedJson);
     }
 
     [Fact]

--- a/tests/ReleaseKit.Application.Tests/Tasks/FetchGitLabReleaseBranchTaskTests.cs
+++ b/tests/ReleaseKit.Application.Tests/Tasks/FetchGitLabReleaseBranchTaskTests.cs
@@ -687,24 +687,25 @@ public class FetchGitLabReleaseBranchTaskTests
         // Act
         await task.ExecuteAsync();
 
-        // Assert - 驗證排序：標準 release/yyyyMMdd 在前面且降冪排序，非標準的在中間，NotFound 最後
+        // Assert - 驗證：標準 release/yyyyMMdd 降冪排序在前，非標準格式歸入 NotFound
         Assert.NotNull(savedJson);
         var indexOf20260210 = savedJson.IndexOf("release/20260210", StringComparison.Ordinal);
         var indexOf20260115 = savedJson.IndexOf("release/20260115", StringComparison.Ordinal);
-        var indexOfV2 = savedJson.IndexOf("release/v2.0", StringComparison.Ordinal);
-        var indexOfHotfix = savedJson.IndexOf("release/hotfix", StringComparison.Ordinal);
         var indexOfNotFound = savedJson.IndexOf("NotFound", StringComparison.Ordinal);
 
         // 標準格式的 branch 應該在最前面且降冪排序
         Assert.True(indexOf20260210 < indexOf20260115, "release/20260210 應該在 release/20260115 之前");
-        
-        // 標準格式應該在非標準格式之前
-        Assert.True(indexOf20260115 < indexOfV2, "標準格式應該在非標準格式之前");
-        Assert.True(indexOf20260115 < indexOfHotfix, "標準格式應該在非標準格式之前");
-        
-        // NotFound 應該在最後
-        Assert.True(indexOfV2 < indexOfNotFound, "非標準 branch 應該在 NotFound 之前");
-        Assert.True(indexOfHotfix < indexOfNotFound, "非標準 branch 應該在 NotFound 之前");
+
+        // 非標準格式（release/v2.0、release/hotfix）不應出現為獨立分組
+        Assert.Equal(-1, savedJson.IndexOf("release/v2.0", StringComparison.Ordinal));
+        Assert.Equal(-1, savedJson.IndexOf("release/hotfix", StringComparison.Ordinal));
+
+        // NotFound 應包含非標準格式的專案與無分支的專案
+        Assert.True(indexOfNotFound > 0, "應有 NotFound 分組");
+        Assert.True(indexOf20260115 < indexOfNotFound, "標準格式應該在 NotFound 之前");
+        Assert.Contains("group/project-custom1", savedJson);
+        Assert.Contains("group/project-custom2", savedJson);
+        Assert.Contains("group/project-none", savedJson);
     }
 
     [Fact]


### PR DESCRIPTION
BaseFetchReleaseBranchTask 原先僅以 release/ 前綴過濾分支，未驗證日期格式，
 release branch。

- 使用 ReleaseBranchHelper.SortReleaseBranchesDescending() 取代字母排序
- 使用 ReleaseBranchHelper.IsReleaseBranch() 取代手動 inline pattern 判斷
- 有分支但無合法格式時歸入 NotFound 分組
- 更新 GitLab/Bitbucket 排序測試以反映新行為